### PR TITLE
Raise exception when Conduit access is not accepted for Passphrase

### DIFF
--- a/phabfive/passphrase.py
+++ b/phabfive/passphrase.py
@@ -44,6 +44,17 @@ class Passphrase(Phabfive):
             # is INFO, even if env PHABFIVE_DEBUG=1
             log.debug(json.dumps(response["data"], indent=2))
 
+        # When Conduit Access is not accepted for Passphrase the "response" will return value "noAPIAccess" in key "material" instead of the secret
+        if (
+            "noAPIAccess"
+            in response["data"].get(next(iter(response["data"])))["material"]
+        ):
+            raise PhabfiveDataException(
+                response["data"]
+                .get(next(iter(response["data"])))["material"]
+                .get("noAPIAccess")
+            )
+
         return response["data"]
 
     def print_secret(self, ids):

--- a/phabfive/passphrase.py
+++ b/phabfive/passphrase.py
@@ -45,10 +45,12 @@ class Passphrase(Phabfive):
             log.debug(json.dumps(response["data"], indent=2))
 
         # When Conduit Access is not accepted for Passphrase the "response" will return value "noAPIAccess" in key "material" instead of the secret
-        if (
+        no_api_access = (
             "noAPIAccess"
             in response["data"].get(next(iter(response["data"])))["material"]
-        ):
+        )
+
+        if no_api_access:
             raise PhabfiveDataException(
                 response["data"]
                 .get(next(iter(response["data"])))["material"]

--- a/phabfive/passphrase.py
+++ b/phabfive/passphrase.py
@@ -45,17 +45,13 @@ class Passphrase(Phabfive):
             log.debug(json.dumps(response["data"], indent=2))
 
         # When Conduit Access is not accepted for Passphrase the "response" will return value "noAPIAccess" in key "material" instead of the secret
-        no_api_access = (
-            "noAPIAccess"
-            in response["data"].get(next(iter(response["data"])))["material"]
-        )
+        api_access_value = response["data"].get(next(iter(response["data"])))[
+            "material"
+        ]
+        no_api_access = "noAPIAccess" in api_access_value
 
         if no_api_access:
-            raise PhabfiveDataException(
-                response["data"]
-                .get(next(iter(response["data"])))["material"]
-                .get("noAPIAccess")
-            )
+            raise PhabfiveDataException(api_access_value.get("noAPIAccess"))
 
         return response["data"]
 


### PR DESCRIPTION
**Before:**
`phabfive passphrase K1`
```
(empty)
```
`phabfive passphrase K2`
```
<password K2 shown>
```

**After:**
`phabfive passphrase K1`
```
This private material for this credential is not accessible via API calls.
```
`phabfive passphrase K2`
```
<password K2 shown>
```

When using print function to check what `self.phab.passphrase.query` returns you can see that the key value `material` returns a dict with different key values. In this case it returns key value `password` when you can access the secret via API, or `noAPIAccess` when you cannot access the secret via API. From this the we can catch `noAPIAccess` and raise is as an `Exception`.

`phabfive passphrase K1` (with print function)
```
'material': {'noAPIAccess': 'This private material for this credential is not accessible via API calls.'}}}, 'cursor': {'limit': 100, 'after': None, 'before': None}}>
```
`phabfive passphrase K2` (with print function)
```
'material': {'password': '<password K2 shown>'}}}, 'cursor': {'limit': 100, 'after': None, 'before': None}}>
```
