### PR TITLE
Function to get clone uri(s) from repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A summary of the currently supported actions, as well as planned features:
 - Diffusion
   - [X] List repositories names
   - [X] Get branches for specified repository
-  - [ ] Get clone URI:s for specified repository
+  - [X] Get clone URI:s for specified repository
   - [X] Add repository
   - [X] Edit URI
   - [X] Observe repositories: create uri

--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -53,8 +53,8 @@ sub_diffusion_args = """
 Usage:
     phabfive diffusion repo list [(active || inactive || all)] [options]
     phabfive diffusion repo create <name> [options]
-    phabfive diffusion uri create (--observe || --mirror) (<credential>) <repo> <uri> [options]
     phabfive diffusion uri list <repo> [options]
+    phabfive diffusion uri create (--observe || --mirror) (<credential>) <repo> <uri> [options]
     phabfive diffusion uri edit <repo> <uri> [(--enable || --disable)] [options]
     phabfive diffusion branch list <repo> [options]
 
@@ -66,7 +66,12 @@ Arguments:
 
 Options:
     -h, --help                     Show this help message and exit
+
+Repo List Options:
     -u, --url                      Show url
+
+Uri List Options:
+    -c, --clone                    Show clone url(s)
 
 Uri Edit Options:
     -n, --new_uri=<value>  Change repository URI
@@ -186,7 +191,7 @@ def run(cli_args, sub_args):
                     )
                     print(created_uri)
                 elif sub_args["list"]:
-                    d.print_uri(repo=sub_args["<repo>"])
+                    d.print_uri(repo=sub_args["<repo>"], clone=sub_args["--clone"])
                 elif sub_args["edit"]:
                     object_id = d.get_object_identifier(
                         repo_name=sub_args["<repo>"], uri_name=sub_args["<uri>"]

--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -191,7 +191,7 @@ def run(cli_args, sub_args):
                     )
                     print(created_uri)
                 elif sub_args["list"]:
-                    d.print_uri(repo=sub_args["<repo>"], clone=sub_args["--clone"])
+                    d.print_uri(repo=sub_args["<repo>"], clone_uri=sub_args["--clone"])
                 elif sub_args["edit"]:
                     object_id = d.get_object_identifier(
                         repo_name=sub_args["<repo>"], uri_name=sub_args["<uri>"]

--- a/phabfive/diffusion.py
+++ b/phabfive/diffusion.py
@@ -295,15 +295,15 @@ class Diffusion(Phabfive):
     # TODO: add support for repo_shortname, etc, see get_branches()
     # TODO: add support for handling active vs inactive repos
     # TODO: add support for handling hidden URIs
-    def get_uris(self, repo_id=None, clone=None):
+    def get_uris(self, repo_id=None, clone_uri=None):
         """Phabfive wrapper that connects to Phabricator and list uri for specific repository.
 
         :type repo_id: str
-        :type clone: bool
+        :type clone_uri: bool
 
         :rtype: list
         """
-        clone = clone if clone else False
+        clone_uri = clone_uri if clone_uri else False
         uris = []
         repos = self.get_repositories(attachments={"uris": True})
 
@@ -313,7 +313,7 @@ class Diffusion(Phabfive):
         for repo in repos:
             if repo_id == repo["fields"]["shortName"]:
                 no_of_uris = repo["attachments"]["uris"]["uris"]
-                if clone:
+                if clone_uri:
                     for uri in no_of_uris:
                         if "always" not in uri["fields"]["display"]["effective"]:
                             continue
@@ -325,13 +325,17 @@ class Diffusion(Phabfive):
         return uris
 
     # TODO: the URIs should be sorted when printed
-    def print_uri(self, repo, clone):
-        """Method used by the Phabfive CLI."""
+    def print_uri(self, repo, clone_uri):
+        """Method used by the Phabfive CLI.
+
+        :type repo: str
+        :type clone_uri: bool
+        """
         if self._validate_identifier(repo):
             repo = repo.replace("R", "")
-            uris = self.get_uris(repo_id=repo, clone=clone)
+            uris = self.get_uris(repo_id=repo, clone_uri=clone_uri)
         else:
-            uris = self.get_uris(repo_id=repo, clone=clone)
+            uris = self.get_uris(repo_id=repo, clone_uri=clone_uri)
 
         for uri in uris:
             print(uri)


### PR DESCRIPTION
`phabfive diffusion uri list <repo>` exist and can list all uri associated with a specific repo. 
`phabfive diffusion uri list <repo> --clone` lists the clone uri(s)