### PR TITLE
Feature/maniphest app

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -61,7 +61,7 @@ cd tests
 docker-compose up -d
 ```
 
-Now Phabricator is accessible on localhost. Go to http://127.0.0.1/ and log in with user `user` and password `bitnami1`, then head over to http://127.0.0.1/settings/user/user/page/apitokens/ to create your Conduit API token. Add those to `~/.config/phabfive.yaml`, here is an example:
+Now Phabricator is accessible on localhost. Go to https://127.0.0.1/ and log in with user `user` and password `bitnami1`, then head over to https://127.0.0.1/settings/user/user/page/apitokens/ to create your Conduit API token. Add those to `~/.config/phabfive.yaml`, here is an example:
 ```
 PHAB_URL: http://127.0.0.1/api/
 PHAB_TOKEN: api-2hwi... (your token)

--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -7,7 +7,7 @@ import re
 import sys
 
 # phabfive imports
-from phabfive import passphrase, diffusion, paste, user
+from phabfive import passphrase, diffusion, paste, user, repl
 from phabfive.constants import MONOGRAMS, REPO_STATUS_CHOICES
 from phabfive.exceptions import (
     PhabfiveConfigException,
@@ -27,6 +27,7 @@ Available phabfive commands are:
     passphrase          The passphrase app
     diffusion           The diffusion app
     paste               The paste app
+    repl                Enter a REPL where API access is possible
     user                Information on users
 
 Shortcuts to Phabricator monograms:
@@ -107,6 +108,14 @@ Options:
     -h, --help           Show this help message and exit
 """
 
+sub_repl_args = """
+Usage:
+    phabfive repl [options]
+
+Options:
+    -h, --help           Show this help message and exit
+"""
+
 
 def parse_cli():
     """Parse the CLI arguments and options."""
@@ -151,11 +160,14 @@ def parse_cli():
         sub_args = docopt(sub_paste_args, argv=argv)
     elif cli_args["<command>"] == "user":
         sub_args = docopt(sub_user_args, argv=argv)
+    elif cli_args["<command>"] == "repl":
+        sub_args = docopt(sub_repl_args, argv=argv)
     else:
         extras(True, phabfive.__version__, [Option("-h", "--help", 0, True)], base_args)
         sys.exit(1)
 
-    sub_args["<sub_command>"] = cli_args["<args>"][0]
+    if len(cli_args["<args>"]) > 0:
+        sub_args["<sub_command>"] = cli_args["<args>"][0]
 
     return (cli_args, sub_args)
 
@@ -258,6 +270,10 @@ def run(cli_args, sub_args):
             u = user.User()
             if sub_args["whoami"]:
                 u.print_whoami()
+
+        if cli_args["<command>"] == "repl":
+            r = repl.Repl()
+            r.run()
 
     except (
         PhabfiveConfigException,

--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -291,7 +291,7 @@ def run(cli_args, sub_args):
 
         if cli_args["<command>"] == "maniphest":
             m = maniphest.Maniphest()
-            
+
             if sub_args["add"] and sub_args["comment"]:
                 result = m.add_comment(
                     sub_args['<ticket_id>'],
@@ -309,7 +309,7 @@ def run(cli_args, sub_args):
 
                 from datetime import datetime
 
-                ## FIXME: All commented fields should be implemented as some kind of --verbose/--long 
+                # FIXME: All commented fields should be implemented as some kind of --verbose/--long
 
                 # print("Ticket ID:          {0}".format(result["id"]))
                 # print("phid:               {0}".format(result["phid"]))

--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -159,6 +159,8 @@ def parse_cli():
             argv = [app, "show"] + argv
         elif app == "user":
             argv = [app, "whoami"] + argv
+        elif app == "maniphest":
+            argv = [app, "show"] + argv
         cli_args["<args>"] = [monogram]
         cli_args["<command>"] = app
         sub_args = docopt(eval("sub_{app}_args".format(app=app)), argv=argv)
@@ -307,31 +309,27 @@ def run(cli_args, sub_args):
 
                 from datetime import datetime
 
-                print("Ticket ID:          {0}".format(result["id"]))
-                print("phid:               {0}".format(result["phid"]))
-                print("authorPHID:         {0}".format(result["authorPHID"]))
-                print("ownerPHID:          {0}".format(result["ownerPHID"]))
-                print("ccPHIDs:            {0}".format(result["ccPHIDs"]))
-                print("status:             {0}".format(result["status"]))
-                print("statusName:         {0}".format(result["statusName"]))
-                print("isClosed:           {0}".format(result["isClosed"]))
-                print("priority:           {0}".format(result["priority"]))
-                print("priorityColor:      {0}".format(result["priorityColor"]))
-                print("title:              {0}".format(result["title"]))
-                print("description:        {0}".format(result["description"]))
-                print("projectPHIDs:       {0}".format(result["projectPHIDs"]))
-                print("uri:                {0}".format(result["uri"]))
-                print("auxiliary:          {0}".format(result["auxiliary"]))
-                print("objectName:         {0}".format(result["objectName"]))
-                print("dateCreated:        {0} ({1})".format(
-                    result["dateCreated"],
-                    datetime.fromtimestamp(int(result["dateCreated"])),
-                ))
-                print("dateModified:       {0} ({1})".format(
-                    result["dateModified"],
-                    datetime.fromtimestamp(int(result["dateModified"])),
-                ))
-                print("dependsOnTaskPHIDs: {0}".format(result["dependsOnTaskPHIDs"]))
+                ## FIXME: All commented fields should be implemented as some kind of --verbose/--long 
+
+                # print("Ticket ID:          {0}".format(result["id"]))
+                # print("phid:               {0}".format(result["phid"]))
+                # print("authorPHID:         {0}".format(result["authorPHID"]))
+                # print("ownerPHID:          {0}".format(result["ownerPHID"]))
+                # print("ccPHIDs:            {0}".format(result["ccPHIDs"]))
+                print("status:        {0}".format(result["status"]))
+                # print("statusName:         {0}".format(result["statusName"]))
+                # print("isClosed:           {0}".format(result["isClosed"]))
+                print("priority:      {0}".format(result["priority"]))
+                # print("priorityColor:      {0}".format(result["priorityColor"]))
+                print("title:         {0}".format(result["title"]))
+                # print("description:        {0}".format(result["description"]))
+                # print("projectPHIDs:       {0}".format(result["projectPHIDs"]))
+                print("uri:           {0}".format(result["uri"]))
+                # print("auxiliary:          {0}".format(result["auxiliary"]))
+                # print("objectName:         {0}".format(result["objectName"]))
+                print("dateCreated:   {0}".format(datetime.fromtimestamp(int(result["dateCreated"]))))
+                print("dateModified:  {0}".format(datetime.fromtimestamp(int(result["dateModified"]))))
+                # print("dependsOnTaskPHIDs: {0}".format(result["dependsOnTaskPHIDs"]))
 
     except (
         PhabfiveConfigException,

--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -28,7 +28,7 @@ Available phabfive commands are:
     diffusion           The diffusion app
     maniphest           The maniphest app
     paste               The paste app
-    repl                Enter a REPL with API access is possible
+    repl                Enter a REPL with API access
     user                Information on users
 
 Shortcuts to Phabricator monograms:

--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -28,7 +28,7 @@ Available phabfive commands are:
     diffusion           The diffusion app
     maniphest           The maniphest app
     paste               The paste app
-    repl                Enter a REPL where API access is possible
+    repl                Enter a REPL with API access is possible
     user                Information on users
 
 Shortcuts to Phabricator monograms:
@@ -119,8 +119,8 @@ Options:
 
 sub_maniphest_args = """
 Usage:
-    phabfive maniphest add comment <ticket_id> <comment> [options]
-    phabfive maniphest info <ticket_id> [options]
+    phabfive maniphest comment add <ticket_id> <comment> [options]
+    phabfive maniphest show <ticket_id> [options]
 
 Options:
     -h, --help           Show this help message and exit
@@ -302,7 +302,7 @@ def run(cli_args, sub_args):
                     print("Comment successfully added")
                     print("Ticket URI: {0}".format(ticket["uri"]))
 
-            if sub_args["info"]:
+            if sub_args["show"]:
                 _, result = m.info(int(sub_args["<ticket_id>"][1:]))
 
                 from datetime import datetime

--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -292,7 +292,7 @@ def run(cli_args, sub_args):
         if cli_args["<command>"] == "maniphest":
             m = maniphest.Maniphest()
 
-            if sub_args["add"] and sub_args["comment"]:
+            if sub_args["comment"] and sub_args["add"]:
                 result = m.add_comment(sub_args["<ticket_id>"], sub_args["<comment>"],)
                 if result[0]:
                     # Query the ticket to fetch the URI for it

--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -293,10 +293,7 @@ def run(cli_args, sub_args):
             m = maniphest.Maniphest()
 
             if sub_args["add"] and sub_args["comment"]:
-                result = m.add_comment(
-                    sub_args['<ticket_id>'],
-                    sub_args['<comment>'],
-                )
+                result = m.add_comment(sub_args["<ticket_id>"], sub_args["<comment>"],)
                 if result[0]:
                     # Query the ticket to fetch the URI for it
                     _, ticket = m.info(int(sub_args["<ticket_id>"][1:]))
@@ -327,8 +324,16 @@ def run(cli_args, sub_args):
                 print("uri:           {0}".format(result["uri"]))
                 # print("auxiliary:          {0}".format(result["auxiliary"]))
                 # print("objectName:         {0}".format(result["objectName"]))
-                print("dateCreated:   {0}".format(datetime.fromtimestamp(int(result["dateCreated"]))))
-                print("dateModified:  {0}".format(datetime.fromtimestamp(int(result["dateModified"]))))
+                print(
+                    "dateCreated:   {0}".format(
+                        datetime.fromtimestamp(int(result["dateCreated"]))
+                    )
+                )
+                print(
+                    "dateModified:  {0}".format(
+                        datetime.fromtimestamp(int(result["dateModified"]))
+                    )
+                )
                 # print("dependsOnTaskPHIDs: {0}".format(result["dependsOnTaskPHIDs"]))
 
     except (

--- a/phabfive/constants.py
+++ b/phabfive/constants.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 # https://secure.phabricator.com/w/object_name_prefixes/
-MONOGRAMS = {"diffusion": "R[0-9]+", "passphrase": "K[0-9]+", "paste": "P[0-9]+", "maniphest": "T[0-9]+"}
+MONOGRAMS = {
+    "diffusion": "R[0-9]+",
+    "passphrase": "K[0-9]+",
+    "paste": "P[0-9]+",
+    "maniphest": "T[0-9]+",
+}
 # IO_EDIT_URI_VALUES = ["default", "read", "write", "never"]
 IO_NEW_URI_CHOICES = ["default", "observe", "mirror", "never"]
 DISPLAY_CHOICES = ["default", "always", "hidden"]

--- a/phabfive/constants.py
+++ b/phabfive/constants.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # https://secure.phabricator.com/w/object_name_prefixes/
-MONOGRAMS = {"diffusion": "R[0-9]+", "passphrase": "K[0-9]+", "paste": "P[0-9]+"}
+MONOGRAMS = {"diffusion": "R[0-9]+", "passphrase": "K[0-9]+", "paste": "P[0-9]+", "maniphest": "T[0-9]+"}
 # IO_EDIT_URI_VALUES = ["default", "read", "write", "never"]
 IO_NEW_URI_CHOICES = ["default", "observe", "mirror", "never"]
 DISPLAY_CHOICES = ["default", "always", "hidden"]

--- a/phabfive/core.py
+++ b/phabfive/core.py
@@ -38,40 +38,47 @@ CONFIG_EXAMPLES = {
 
 
 class Phabfive(object):
-    def __init__(self):
 
+    def __init__(self):
+        """
+        """
         # Get super-early debugging by `export PHABFIVE_DEBUG=1`
         if "PHABFIVE_DEBUG" in os.environ:
             log.setLevel(logging.DEBUG)
-            log.info(
-                "Loglevel is: {}".format(logging.getLevelName(log.getEffectiveLevel()))
-            )
+            log.info("Loglevel is: {}".format(logging.getLevelName(log.getEffectiveLevel())))
 
         self.conf = self.load_config()
 
         maxlen = 8 + len(max(dict(self.conf).keys(), key=len))
+
         for k, v in dict(self.conf).items():
             log.debug("{} {} {}".format(k, "." * (maxlen - len(k)), v))
 
         # check for required configurables
-        for k, v in dict(self.conf).items():
-            if k in REQUIRED and not v:
-                error = "{} is not configured".format(k)
-                example = CONFIG_EXAMPLES.get(k)
+        for conf_key, conf_value in dict(self.conf).items():
+            if conf_key in REQUIRED and not conf_value:
+                error = "{} is not configured".format(conf_key)
+                example = CONFIG_EXAMPLES.get(conf_key)
+
                 if example:
                     error += ", " + example
+
                 raise PhabfiveConfigException(error)
 
         # check validity of configurables
-        for k in VALIDATORS.keys():
-            if not re.match(VALIDATORS[k], self.conf[k]):
-                error = "{} is malformed".format(k)
-                example = VALID_EXAMPLES.get(k)
+        for validator_key in VALIDATORS.keys():
+            if not re.match(VALIDATORS[validator_key], self.conf[validator_key]):
+                error = "{} is malformed".format(validator_key)
+                example = VALID_EXAMPLES.get(validator_key)
+
                 if example:
                     error += ", " + example
+
                 raise PhabfiveConfigException(error)
+
         self.phab = Phabricator(
-            host=self.conf.get("PHAB_URL"), token=self.conf.get("PHAB_TOKEN")
+            host=self.conf.get("PHAB_URL"),
+            token=self.conf.get("PHAB_TOKEN"),
         )
 
         self.verify_connection()

--- a/phabfive/core.py
+++ b/phabfive/core.py
@@ -38,14 +38,15 @@ CONFIG_EXAMPLES = {
 
 
 class Phabfive(object):
-
     def __init__(self):
         """
         """
         # Get super-early debugging by `export PHABFIVE_DEBUG=1`
         if "PHABFIVE_DEBUG" in os.environ:
             log.setLevel(logging.DEBUG)
-            log.info("Loglevel is: {}".format(logging.getLevelName(log.getEffectiveLevel())))
+            log.info(
+                "Loglevel is: {}".format(logging.getLevelName(log.getEffectiveLevel()))
+            )
 
         self.conf = self.load_config()
 
@@ -77,8 +78,7 @@ class Phabfive(object):
                 raise PhabfiveConfigException(error)
 
         self.phab = Phabricator(
-            host=self.conf.get("PHAB_URL"),
-            token=self.conf.get("PHAB_TOKEN"),
+            host=self.conf.get("PHAB_URL"), token=self.conf.get("PHAB_TOKEN"),
         )
         # This enables extra endpoints that normally is unaccessible
         self.phab.update_interfaces()

--- a/phabfive/core.py
+++ b/phabfive/core.py
@@ -80,6 +80,8 @@ class Phabfive(object):
             host=self.conf.get("PHAB_URL"),
             token=self.conf.get("PHAB_TOKEN"),
         )
+        # This enables extra endpoints that normally is unaccessible
+        self.phab.update_interfaces()
 
         self.verify_connection()
 

--- a/phabfive/maniphest.py
+++ b/phabfive/maniphest.py
@@ -5,10 +5,6 @@ import logging
 
 # phabfive imports
 from phabfive.core import Phabfive
-from phabfive.exceptions import PhabfiveRemoteException
-
-# 3rd party imports
-from phabricator import APIError
 
 
 log = logging.getLogger(__name__)

--- a/phabfive/maniphest.py
+++ b/phabfive/maniphest.py
@@ -20,7 +20,7 @@ class Maniphest(Phabfive):
         :type comment_string: str
         """
         result = self.phab.maniphest.edit(
-            transactions=[{"type": "comment", "value": comment_string,}],
+            transactions=[{"type": "comment", "value": comment_string}],
             objectIdentifier=ticket_identifier,
         )
 

--- a/phabfive/maniphest.py
+++ b/phabfive/maniphest.py
@@ -11,7 +11,6 @@ log = logging.getLogger(__name__)
 
 
 class Maniphest(Phabfive):
-
     def __init__(self):
         super(Maniphest, self).__init__()
 
@@ -21,10 +20,7 @@ class Maniphest(Phabfive):
         :type comment_string: str
         """
         result = self.phab.maniphest.edit(
-            transactions=[{
-                "type": "comment",
-                "value": comment_string,
-            }],
+            transactions=[{"type": "comment", "value": comment_string,}],
             objectIdentifier=ticket_identifier,
         )
 
@@ -35,8 +31,6 @@ class Maniphest(Phabfive):
         :type task_id: int
         """
         # FIXME: Add validation and extraction of the int part of the task_id
-        result = self.phab.maniphest.info(
-            task_id=task_id,
-        )
+        result = self.phab.maniphest.info(task_id=task_id,)
 
         return (True, result)

--- a/phabfive/maniphest.py
+++ b/phabfive/maniphest.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+# python std lib
+import logging
+
+# phabfive imports
+from phabfive.core import Phabfive
+from phabfive.exceptions import PhabfiveRemoteException
+
+# 3rd party imports
+from phabricator import APIError
+
+
+log = logging.getLogger(__name__)
+
+
+class Maniphest(Phabfive):
+
+    def __init__(self):
+        super(Maniphest, self).__init__()
+
+    def add_comment(self, ticket_identifier, comment_string):
+        """
+        :type ticket_identifier: str
+        :type comment_string: str
+        """
+        result = self.phab.maniphest.edit(
+            transactions=[{
+                "type": "comment",
+                "value": comment_string,
+            }],
+            objectIdentifier=ticket_identifier,
+        )
+
+        return (True, result["object"])
+
+    def info(self, task_id):
+        """
+        :type task_id: int
+        """
+        # FIXME: Add validation and extraction of the int part of the task_id
+        result = self.phab.maniphest.info(
+            task_id=task_id,
+        )
+
+        return (True, result)

--- a/phabfive/repl.py
+++ b/phabfive/repl.py
@@ -5,10 +5,6 @@ import logging
 
 # phabfive imports
 from phabfive.core import Phabfive
-from phabfive.exceptions import PhabfiveRemoteException
-
-# 3rd party imports
-from phabricator import APIError
 
 
 log = logging.getLogger(__name__)

--- a/phabfive/repl.py
+++ b/phabfive/repl.py
@@ -24,4 +24,5 @@ class Repl(Phabfive):
         from pprint import pprint as pp  # NOQA F01
 
         import pdb
+
         pdb.set_trace()

--- a/phabfive/repl.py
+++ b/phabfive/repl.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# python std lib
+import logging
+
+# phabfive imports
+from phabfive.core import Phabfive
+from phabfive.exceptions import PhabfiveRemoteException
+
+# 3rd party imports
+from phabricator import APIError
+
+
+log = logging.getLogger(__name__)
+
+
+class Repl(Phabfive):
+    def __init__(self):
+        super(Repl, self).__init__()
+
+    def run(self):
+        print("*************")
+        print("use self.phab to access the phacility API")
+        print("use self.conf to access current client configuration")
+        print("use pp() to prettyprint the API response back from self.phab.* calls")
+        print("*************")
+
+        from pprint import pprint as pp
+
+        import pdb
+        pdb.set_trace()

--- a/phabfive/repl.py
+++ b/phabfive/repl.py
@@ -21,7 +21,7 @@ class Repl(Phabfive):
         print("use pp() to prettyprint the API response back from self.phab.* calls")
         print("*************")
 
-        from pprint import pprint as pp
+        from pprint import pprint as pp  # NOQA F01
 
         import pdb
         pdb.set_trace()

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,6 @@ install_requires = ["anyconfig>=0.10.0", "appdirs", "phabricator", "pyyaml", "do
 tests_require = [
     "coverage",
     "flake8",
-    "flake8-assertive",
-    "flake8-black",
-    "flake8-bugbear",
-    "flake8-comprehensions",
-    "flake8-rst-docstrings",
     "pytest",
     "tox",
 ]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,17 @@ with open("CHANGELOG.md") as f:
     CHANGELOG = f.read()
 
 install_requires = ["anyconfig>=0.10.0", "appdirs", "phabricator", "pyyaml", "docopt"]
-tests_require = ["coverage", "flake8", "pytest", "tox"]
+tests_require = [
+    "coverage",
+    "flake8",
+    "flake8-assertive",
+    "flake8-black",
+    "flake8-bugbear",
+    "flake8-comprehensions",
+    "flake8-rst-docstrings",
+    "pytest",
+    "tox",
+]
 docs_require = ["docs"]
 download_url = "{}/tarball/v{}".format(
     "https://github.com/dynamist/phabfive", phabfive.__version__


### PR DESCRIPTION
### Improvements:

Create a new app within phabfive for maniphest. Also added a small helper command for getting into a REPL where access to the API is simpler to reach for testing and debugging of the internals of phabricator API client, very usefull during devleopment.

New supported commands and examples of running them

```
(phabfive) ➜  phabfive git:(feature/maniphest_app) ✗ phabfive maniphest add comment T1 "test from cli"
Comment successfully added              
Ticket URI: https://127.0.0.1/T1                                       
```

```
(phabfive) ➜  phabfive git:(feature/maniphest_app) ✗ phabfive maniphest show T1
Ticket ID:          1
phid:               PHID-TASK-ouldaoojg34napsdneet
authorPHID:         PHID-USER-4m66oxlehcct7p6actyb
ownerPHID:          None
ccPHIDs:            ['PHID-USER-4m66oxlehcct7p6actyb']
status:             open
statusName:         Open
isClosed:           False
priority:           Needs Triage
priorityColor:      violet
title:              gitlab testing thingy...
description:
projectPHIDs:       []
uri:                https://127.0.0.1/T1
auxiliary:          []
objectName:         T1
dateCreated:        1592474276 (2020-06-18 11:57:56)
dateModified:       1592475102 (2020-06-18 12:11:42)
dependsOnTaskPHIDs: []
```

```
(phabfive) ➜  phabfive git:(feature/maniphest_app) phabfive repl
*************
use self.phab to access the phacility API
use self.conf to access current client configuration
use pp() to prettyprint the API response back from self.phab.* calls
*************
--Return--
> /home/grok/dynamist/phabfive/phabfive/repl.py(31)run()->None
-> pdb.set_trace()
(Pdb) 
```

Closes #45 