### PR TITLE
feat(maniphest): Add project wildcard search and resolution

### DIFF
--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -119,7 +119,10 @@ Usage:
     phabfive maniphest search <project_name> [options]
 
 Search Arguments:
-    <project_name>       The name of the project
+    <project_name>       Project name or wildcard pattern.
+                         Supports: "*" (all projects), "prefix*" (starts with),
+                         "*suffix" (ends with), "*contains*" (contains text).
+                         Empty string "" returns no results.
 
 Search Options:
     --created-after=N    Tasks created within the last N days


### PR DESCRIPTION
Adds wildcard pattern matching and case-insensitive project name resolution to `maniphest search` command.

## Features

### Wildcard Search Patterns
- `*` - Match all projects
- `prefix*` - Match projects starting with prefix
- `*suffix` - Match projects ending with suffix
- `*contains*` - Match projects containing text

### Case-Insensitive Matching
All project name comparisons are now case-insensitive:
- Exact matches: `myproject`, `MyProject`, `MYPROJECT` all match
- Wildcard patterns: `dev*` matches `Development`, `DevOps`, etc.
- Suggestions: Error messages suggest similar projects regardless of case

## Implementation

**New Method**: `_resolve_project_phids`
- Validates project input
- Fetches all projects from Phabricator
- Creates lowercase lookup mappings for case-insensitive matching
- Handles wildcard patterns using `fnmatch`
- Provides suggestions using `difflib` with adaptive cutoff scoring

**Changes to `task_search()`**:
- Now calls `_resolve_project_phids()` to resolve project names/patterns to PHIDs
- Supports multiple project PHIDs from wildcard matches

## Examples

```bash
# Search all projects
phabfive maniphest search "*"

# Search projects starting with "Dev"
phabfive maniphest search "Dev*"

# Case-insensitive exact match
phabfive maniphest search "myproject"  # matches "MyProject"

# Suggestions for "developement"
phabfive maniphest search "developement"
# ERROR - Project 'developement' not found. Did you mean: Development?
```

Closes #72

Relates to #69