### PR TITLE
feat(maniphest): Add Priority Filtering and Restructure Task Output

### DIFF
--- a/phabfive/priority_transitions.py
+++ b/phabfive/priority_transitions.py
@@ -1,0 +1,353 @@
+# -*- coding: utf-8 -*-
+
+# python std lib
+import logging
+
+# phabfive imports
+from phabfive.exceptions import PhabfiveException
+
+log = logging.getLogger(__name__)
+
+# Priority ordering for comparison and sorting
+# Lower number = higher/more urgent priority
+# Used to determine if priority was "raised" (decreased number) or "lowered" (increased number)
+# NOTE: This is separate from the API numeric values (100, 90, 80, 50, 25, 0)
+PRIORITY_ORDER = {
+    "unbreak now!": 0,
+    "triage": 1,
+    "high": 2,
+    "normal": 3,
+    "low": 4,
+    "wishlist": 5,
+}
+
+
+def get_priority_order(priority_name):
+    """
+    Get the numeric order of a priority for comparison.
+
+    Parameters
+    ----------
+    priority_name : str
+        Priority name (case-insensitive)
+
+    Returns
+    -------
+    int or None
+        Priority order number, or None if not found
+    """
+    if not priority_name:
+        return None
+    return PRIORITY_ORDER.get(priority_name.lower())
+
+
+class PriorityPattern:
+    """
+    Represents a single priority pattern with AND conditions.
+
+    A pattern can have multiple conditions that must all match (AND logic).
+    Multiple patterns can be combined with OR logic.
+    """
+
+    def __init__(self, conditions):
+        """
+        Parameters
+        ----------
+        conditions : list
+            List of condition dicts, each with keys like:
+            {"type": "from", "priority": "High", "direction": "raised"}
+        """
+        self.conditions = conditions
+
+    def matches(self, priority_transactions, current_priority):
+        """
+        Check if all conditions in this pattern match (AND logic).
+
+        Parameters
+        ----------
+        priority_transactions : list
+            List of priority change transactions for a task
+        current_priority : str or None
+            Current priority name
+
+        Returns
+        -------
+        bool
+            True if all conditions match, False otherwise
+        """
+        # All conditions must match for the pattern to match
+        for condition in self.conditions:
+            if not self._matches_condition(condition, priority_transactions, current_priority):
+                return False
+        return True
+
+    def _matches_condition(self, condition, priority_transactions, current_priority):
+        """Check if a single condition matches."""
+        condition_type = condition.get("type")
+
+        if condition_type == "from":
+            return self._matches_from(condition, priority_transactions)
+        elif condition_type == "to":
+            return self._matches_to(condition, priority_transactions)
+        elif condition_type == "in":
+            return self._matches_current(condition, current_priority)
+        elif condition_type == "been":
+            return self._matches_been(condition, priority_transactions)
+        elif condition_type == "never":
+            return self._matches_never(condition, priority_transactions)
+        elif condition_type == "raised":
+            return self._matches_raised(priority_transactions)
+        elif condition_type == "lowered":
+            return self._matches_lowered(priority_transactions)
+        else:
+            log.warning(f"Unknown condition type: {condition_type}")
+            return False
+
+    def _matches_from(self, condition, priority_transactions):
+        """Match 'from:PRIORITY[:direction]' pattern."""
+        target_priority = condition.get("priority")
+        direction = condition.get("direction")  # None, "raised", or "lowered"
+
+        for trans in priority_transactions:
+            old_value = trans.get("oldValue")
+            new_value = trans.get("newValue")
+
+            if old_value is None or new_value is None:
+                continue
+
+            # Check if old priority matches target (case-insensitive)
+            if old_value.lower() == target_priority.lower():
+                # If no direction specified, it's a match
+                if direction is None:
+                    return True
+
+                # Check direction
+                old_order = get_priority_order(old_value)
+                new_order = get_priority_order(new_value)
+
+                if old_order is not None and new_order is not None:
+                    if direction == "raised" and new_order < old_order:
+                        return True
+                    elif direction == "lowered" and new_order > old_order:
+                        return True
+
+        return False
+
+    def _matches_to(self, condition, priority_transactions):
+        """Match 'to:PRIORITY' pattern."""
+        target_priority = condition.get("priority")
+
+        for trans in priority_transactions:
+            new_value = trans.get("newValue")
+
+            if new_value is None:
+                continue
+
+            if new_value.lower() == target_priority.lower():
+                return True
+
+        return False
+
+    def _matches_current(self, condition, current_priority):
+        """Match 'in:PRIORITY' pattern."""
+        target_priority = condition.get("priority")
+        if not current_priority:
+            return False
+        return current_priority.lower() == target_priority.lower()
+
+    def _matches_been(self, condition, priority_transactions):
+        """Match 'been:PRIORITY' pattern - task was at priority at any point."""
+        target_priority = condition.get("priority")
+
+        for trans in priority_transactions:
+            old_value = trans.get("oldValue")
+            new_value = trans.get("newValue")
+
+            # Check both old and new values
+            for value in [old_value, new_value]:
+                if value and value.lower() == target_priority.lower():
+                    return True
+
+        return False
+
+    def _matches_never(self, condition, priority_transactions):
+        """Match 'never:PRIORITY' pattern - task was never at priority."""
+        target_priority = condition.get("priority")
+
+        for trans in priority_transactions:
+            old_value = trans.get("oldValue")
+            new_value = trans.get("newValue")
+
+            # Check both old and new values
+            for value in [old_value, new_value]:
+                if value and value.lower() == target_priority.lower():
+                    return False  # Found the priority, so it's not "never"
+
+        return True  # Never found the priority
+
+    def _matches_raised(self, priority_transactions):
+        """Match 'raised' pattern - any priority increase (lower number = higher priority)."""
+        for trans in priority_transactions:
+            old_value = trans.get("oldValue")
+            new_value = trans.get("newValue")
+
+            if old_value is None or new_value is None:
+                continue
+
+            old_order = get_priority_order(old_value)
+            new_order = get_priority_order(new_value)
+
+            if old_order is not None and new_order is not None:
+                if new_order < old_order:  # Lower number = higher priority
+                    return True
+
+        return False
+
+    def _matches_lowered(self, priority_transactions):
+        """Match 'lowered' pattern - any priority decrease (higher number = lower priority)."""
+        for trans in priority_transactions:
+            old_value = trans.get("oldValue")
+            new_value = trans.get("newValue")
+
+            if old_value is None or new_value is None:
+                continue
+
+            old_order = get_priority_order(old_value)
+            new_order = get_priority_order(new_value)
+
+            if old_order is not None and new_order is not None:
+                if new_order > old_order:  # Higher number = lower priority
+                    return True
+
+        return False
+
+
+def _parse_single_condition(condition_str):
+    """
+    Parse a single condition string.
+
+    Parameters
+    ----------
+    condition_str : str
+        Condition like "from:High:raised", "in:Normal", "raised", "lowered"
+
+    Returns
+    -------
+    dict
+        Condition dict with keys like {"type": "from", "priority": "High", "direction": "raised"}
+
+    Raises
+    ------
+    PhabfiveException
+        If condition syntax is invalid
+    """
+    condition_str = condition_str.strip()
+
+    # Special keywords without parameters
+    if condition_str == "raised":
+        return {"type": "raised"}
+    elif condition_str == "lowered":
+        return {"type": "lowered"}
+
+    # Patterns with parameters: type:value or type:value:direction
+    if ":" not in condition_str:
+        raise PhabfiveException(f"Invalid priority condition syntax: '{condition_str}'")
+
+    parts = condition_str.split(":", 2)  # Split into max 3 parts
+    condition_type = parts[0].strip()
+
+    if condition_type not in ["from", "to", "in", "been", "never"]:
+        raise PhabfiveException(
+            f"Invalid priority condition type: '{condition_type}'. "
+            f"Valid types: from, to, in, been, never, raised, lowered"
+        )
+
+    if len(parts) < 2:
+        raise PhabfiveException(f"Missing priority name for condition: '{condition_str}'")
+
+    priority_name = parts[1].strip()
+    if not priority_name:
+        raise PhabfiveException(f"Empty priority name in condition: '{condition_str}'")
+
+    result = {"type": condition_type, "priority": priority_name}
+
+    # Handle optional direction for 'from' patterns
+    if len(parts) == 3:
+        if condition_type != "from":
+            raise PhabfiveException(
+                f"Direction modifier only allowed for 'from' patterns, got: '{condition_str}'"
+            )
+        direction = parts[2].strip()
+        if direction not in ["raised", "lowered"]:
+            raise PhabfiveException(
+                f"Invalid direction: '{direction}'. Must be 'raised' or 'lowered'"
+            )
+        result["direction"] = direction
+
+    return result
+
+
+def parse_priority_patterns(patterns_str):
+    """
+    Parse priority pattern string into list of PriorityPattern objects.
+
+    Supports:
+    - Comma (,) for OR logic between patterns
+    - Plus (+) for AND logic within a pattern
+
+    Parameters
+    ----------
+    patterns_str : str
+        Pattern string like "from:Normal:raised+in:High,to:Unbreak Now!"
+
+    Returns
+    -------
+    list
+        List of PriorityPattern objects
+
+    Raises
+    ------
+    PhabfiveException
+        If pattern syntax is invalid
+
+    Examples
+    --------
+    >>> parse_priority_patterns("from:Normal:raised")
+    [PriorityPattern([{"type": "from", "priority": "Normal", "direction": "raised"}])]
+
+    >>> parse_priority_patterns("from:High+in:Normal,to:Low")
+    [PriorityPattern([from:High, in:Normal]), PriorityPattern([to:Low])]
+    """
+    if not patterns_str or not patterns_str.strip():
+        raise PhabfiveException("Empty priority pattern")
+
+    patterns = []
+
+    # Split by comma for OR groups
+    or_groups = patterns_str.split(",")
+
+    for or_group in or_groups:
+        or_group = or_group.strip()
+        if not or_group:
+            continue
+
+        conditions = []
+
+        # Split by plus for AND conditions
+        and_parts = or_group.split("+")
+
+        for and_part in and_parts:
+            and_part = and_part.strip()
+            if not and_part:
+                continue
+
+            condition = _parse_single_condition(and_part)
+            conditions.append(condition)
+
+        if conditions:
+            patterns.append(PriorityPattern(conditions))
+
+    if not patterns:
+        raise PhabfiveException("No valid priority patterns found")
+
+    return patterns

--- a/tests/test_maniphest.py
+++ b/tests/test_maniphest.py
@@ -409,7 +409,7 @@ class TestPrintTaskColumns:
 
         boards = {"PHID-PROJ-123": {"columns": [{"name": "Backlog"}, {"name": "Done"}]}}
 
-        maniphest._print_task_boards(boards, {}, {}, None)
+        maniphest._print_task_boards(boards, {})
         # Updated expectations for new board format which shows nested structure
         assert mock_print.called
 
@@ -422,7 +422,7 @@ class TestPrintTaskColumns:
         boards = {"PHID-PROJ-123": {"columns": [{"name": "Backlog"}]}}
         project_names = {"PHID-PROJ-123": "Project A"}
 
-        maniphest._print_task_boards(boards, project_names, {}, None)
+        maniphest._print_task_boards(boards, project_names)
         # New board display format shows nested structure with project name
         assert mock_print.called
 
@@ -436,7 +436,7 @@ class TestPrintTaskColumns:
         boards = []  # List format
 
         # Should not crash, just return without printing
-        maniphest._print_task_boards(boards, {}, {}, None)
+        maniphest._print_task_boards(boards, {})
         mock_print.assert_not_called()
 
     @patch("phabfive.maniphest.Phabfive.__init__")
@@ -449,7 +449,7 @@ class TestPrintTaskColumns:
         boards = []  # List format
 
         # Should not crash, just return without printing
-        maniphest._print_task_boards(boards, {}, {}, None)
+        maniphest._print_task_boards(boards, {})
         mock_print.assert_not_called()
 
 
@@ -857,10 +857,10 @@ class TestTransitionFilteringIntegration:
             {"data": [{"id": 2}]}
         ]
 
-        matches1, _ = maniphest._task_matches_any_pattern(
+        matches1, _, _ = maniphest._task_matches_any_pattern(
             task1, "PHID-TASK-1", patterns, ["PHID-PROJ-123"]
         )
-        matches2, _ = maniphest._task_matches_any_pattern(
+        matches2, _, _ = maniphest._task_matches_any_pattern(
             task2, "PHID-TASK-2", patterns, ["PHID-PROJ-123"]
         )
 

--- a/tests/test_priority_transitions.py
+++ b/tests/test_priority_transitions.py
@@ -1,0 +1,414 @@
+# -*- coding: utf-8 -*-
+
+# 3rd party imports
+import pytest
+
+# phabfive imports
+from phabfive.priority_transitions import (
+    PriorityPattern,
+    _parse_single_condition,
+    parse_priority_patterns,
+    get_priority_order,
+    PRIORITY_ORDER,
+)
+from phabfive.exceptions import PhabfiveException
+
+
+class TestGetPriorityOrder:
+    def test_unbreak_now(self):
+        assert get_priority_order("Unbreak Now!") == 0
+
+    def test_triage(self):
+        assert get_priority_order("Triage") == 1
+
+    def test_high(self):
+        assert get_priority_order("High") == 2
+
+    def test_normal(self):
+        assert get_priority_order("Normal") == 3
+
+    def test_low(self):
+        assert get_priority_order("Low") == 4
+
+    def test_wishlist(self):
+        assert get_priority_order("Wishlist") == 5
+
+    def test_case_insensitive(self):
+        assert get_priority_order("UNBREAK NOW!") == 0
+        assert get_priority_order("high") == 2
+        assert get_priority_order("NoRmAl") == 3
+
+    def test_unknown_priority(self):
+        assert get_priority_order("Unknown") is None
+
+    def test_none_input(self):
+        assert get_priority_order(None) is None
+
+    def test_empty_string(self):
+        assert get_priority_order("") is None
+
+
+class TestParseSingleCondition:
+    def test_parse_raised(self):
+        result = _parse_single_condition("raised")
+        assert result == {"type": "raised"}
+
+    def test_parse_lowered(self):
+        result = _parse_single_condition("lowered")
+        assert result == {"type": "lowered"}
+
+    def test_parse_from_simple(self):
+        result = _parse_single_condition("from:Normal")
+        assert result == {"type": "from", "priority": "Normal"}
+
+    def test_parse_from_with_raised(self):
+        result = _parse_single_condition("from:Normal:raised")
+        assert result == {"type": "from", "priority": "Normal", "direction": "raised"}
+
+    def test_parse_from_with_lowered(self):
+        result = _parse_single_condition("from:High:lowered")
+        assert result == {"type": "from", "priority": "High", "direction": "lowered"}
+
+    def test_parse_to(self):
+        result = _parse_single_condition("to:Unbreak Now!")
+        assert result == {"type": "to", "priority": "Unbreak Now!"}
+
+    def test_parse_in(self):
+        result = _parse_single_condition("in:High")
+        assert result == {"type": "in", "priority": "High"}
+
+    def test_parse_been(self):
+        result = _parse_single_condition("been:Unbreak Now!")
+        assert result == {"type": "been", "priority": "Unbreak Now!"}
+
+    def test_parse_never(self):
+        result = _parse_single_condition("never:Low")
+        assert result == {"type": "never", "priority": "Low"}
+
+    def test_invalid_type(self):
+        with pytest.raises(PhabfiveException) as exc:
+            _parse_single_condition("invalid:Priority")
+        assert "Invalid priority condition type" in str(exc.value)
+
+    def test_missing_colon(self):
+        with pytest.raises(PhabfiveException) as exc:
+            _parse_single_condition("notavalidpattern")
+        assert "Invalid priority condition syntax" in str(exc.value)
+
+    def test_empty_priority_name(self):
+        with pytest.raises(PhabfiveException) as exc:
+            _parse_single_condition("from:")
+        assert "Empty priority name" in str(exc.value)
+
+    def test_direction_on_non_from(self):
+        with pytest.raises(PhabfiveException) as exc:
+            _parse_single_condition("to:High:raised")
+        assert "Direction modifier only allowed for 'from' patterns" in str(exc.value)
+
+    def test_invalid_direction(self):
+        with pytest.raises(PhabfiveException) as exc:
+            _parse_single_condition("from:Normal:invalid")
+        assert "Invalid direction" in str(exc.value)
+
+
+class TestParsePriorityPatterns:
+    def test_single_simple_pattern(self):
+        patterns = parse_priority_patterns("raised")
+        assert len(patterns) == 1
+        assert len(patterns[0].conditions) == 1
+        assert patterns[0].conditions[0]["type"] == "raised"
+
+    def test_single_from_pattern(self):
+        patterns = parse_priority_patterns("from:Normal:raised")
+        assert len(patterns) == 1
+        assert patterns[0].conditions[0] == {
+            "type": "from",
+            "priority": "Normal",
+            "direction": "raised"
+        }
+
+    def test_or_patterns_with_comma(self):
+        patterns = parse_priority_patterns("raised,to:High")
+        assert len(patterns) == 2
+        assert patterns[0].conditions[0]["type"] == "raised"
+        assert patterns[1].conditions[0] == {"type": "to", "priority": "High"}
+
+    def test_and_patterns_with_plus(self):
+        patterns = parse_priority_patterns("from:Normal+in:High")
+        assert len(patterns) == 1
+        assert len(patterns[0].conditions) == 2
+        assert patterns[0].conditions[0] == {"type": "from", "priority": "Normal"}
+        assert patterns[0].conditions[1] == {"type": "in", "priority": "High"}
+
+    def test_complex_or_and_combination(self):
+        patterns = parse_priority_patterns("from:Normal:raised+in:High,to:Low")
+        assert len(patterns) == 2
+        # First pattern: from:Normal:raised AND in:High
+        assert len(patterns[0].conditions) == 2
+        # Second pattern: to:Low
+        assert len(patterns[1].conditions) == 1
+
+    def test_empty_pattern_error(self):
+        with pytest.raises(PhabfiveException) as exc:
+            parse_priority_patterns("")
+        assert "Empty priority pattern" in str(exc.value)
+
+    def test_whitespace_handling(self):
+        patterns = parse_priority_patterns(" from:Normal , to:High ")
+        assert len(patterns) == 2
+
+
+class TestPriorityPatternMatching:
+    def test_matches_raised(self):
+        pattern = PriorityPattern([{"type": "raised"}])
+
+        # Transaction with priority increase (Normal -> High)
+        transactions = [
+            {
+                "oldValue": "Normal",
+                "newValue": "High",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "High") is True
+
+    def test_matches_lowered(self):
+        pattern = PriorityPattern([{"type": "lowered"}])
+
+        # Transaction with priority decrease (High -> Normal)
+        transactions = [
+            {
+                "oldValue": "High",
+                "newValue": "Normal",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "Normal") is True
+
+    def test_matches_from_with_raised_direction(self):
+        pattern = PriorityPattern([{"type": "from", "priority": "Normal", "direction": "raised"}])
+
+        transactions = [
+            {
+                "oldValue": "Normal",
+                "newValue": "High",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "High") is True
+
+    def test_matches_from_with_lowered_direction(self):
+        pattern = PriorityPattern([{"type": "from", "priority": "High", "direction": "lowered"}])
+
+        transactions = [
+            {
+                "oldValue": "High",
+                "newValue": "Normal",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "Normal") is True
+
+    def test_matches_in(self):
+        pattern = PriorityPattern([{"type": "in", "priority": "High"}])
+
+        assert pattern.matches([], "High") is True
+        assert pattern.matches([], "Normal") is False
+
+    def test_matches_to(self):
+        pattern = PriorityPattern([{"type": "to", "priority": "Unbreak Now!"}])
+
+        transactions = [
+            {
+                "oldValue": "Normal",
+                "newValue": "Unbreak Now!",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "Unbreak Now!") is True
+
+    def test_matches_been(self):
+        pattern = PriorityPattern([{"type": "been", "priority": "Unbreak Now!"}])
+
+        transactions = [
+            {
+                "oldValue": "Normal",
+                "newValue": "Unbreak Now!",
+                "dateCreated": 1234567890
+            },
+            {
+                "oldValue": "Unbreak Now!",
+                "newValue": "High",
+                "dateCreated": 1234567891
+            }
+        ]
+
+        assert pattern.matches(transactions, "High") is True
+
+    def test_matches_never(self):
+        pattern = PriorityPattern([{"type": "never", "priority": "Low"}])
+
+        transactions = [
+            {
+                "oldValue": "Normal",
+                "newValue": "High",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "High") is True
+
+    def test_does_not_match_never_when_priority_was_used(self):
+        pattern = PriorityPattern([{"type": "never", "priority": "Low"}])
+
+        transactions = [
+            {
+                "oldValue": "Low",
+                "newValue": "High",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "High") is False
+
+    def test_matches_and_conditions(self):
+        # Pattern with AND: from:Normal AND in:High
+        pattern = PriorityPattern([
+            {"type": "from", "priority": "Normal"},
+            {"type": "in", "priority": "High"}
+        ])
+
+        transactions = [
+            {
+                "oldValue": "Normal",
+                "newValue": "High",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        # Both conditions must match
+        assert pattern.matches(transactions, "High") is True
+        assert pattern.matches(transactions, "Normal") is False
+
+    def test_no_match_raised_when_lowered(self):
+        pattern = PriorityPattern([{"type": "raised"}])
+
+        # Transaction with priority decrease
+        transactions = [
+            {
+                "oldValue": "High",
+                "newValue": "Normal",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "Normal") is False
+
+    def test_no_match_lowered_when_raised(self):
+        pattern = PriorityPattern([{"type": "lowered"}])
+
+        # Transaction with priority increase
+        transactions = [
+            {
+                "oldValue": "Normal",
+                "newValue": "High",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "High") is False
+
+    def test_no_match_to_different_priority(self):
+        pattern = PriorityPattern([{"type": "to", "priority": "High"}])
+
+        transactions = [
+            {
+                "oldValue": "Normal",
+                "newValue": "Low",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "Low") is False
+
+    def test_case_insensitive_matching(self):
+        pattern = PriorityPattern([{"type": "been", "priority": "high"}])
+
+        transactions = [
+            {
+                "oldValue": "Normal",
+                "newValue": "High",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "High") is True
+
+    def test_matches_with_no_transactions(self):
+        pattern = PriorityPattern([{"type": "raised"}])
+        assert pattern.matches([], "Normal") is False
+
+    def test_matches_with_none_values(self):
+        pattern = PriorityPattern([{"type": "raised"}])
+
+        transactions = [
+            {
+                "oldValue": None,
+                "newValue": "High",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "High") is False
+
+    def test_empty_pattern_list(self):
+        """Test that empty conditions list returns False."""
+        pattern = PriorityPattern([])
+        assert pattern.matches([], "Normal") is True  # No conditions to fail
+
+
+class TestPriorityOrdering:
+    """Test that priority ordering is correct for direction detection."""
+
+    def test_priority_order_values(self):
+        """Verify priority order constants are correct."""
+        assert PRIORITY_ORDER["unbreak now!"] < PRIORITY_ORDER["triage"]
+        assert PRIORITY_ORDER["triage"] < PRIORITY_ORDER["high"]
+        assert PRIORITY_ORDER["high"] < PRIORITY_ORDER["normal"]
+        assert PRIORITY_ORDER["normal"] < PRIORITY_ORDER["low"]
+        assert PRIORITY_ORDER["low"] < PRIORITY_ORDER["wishlist"]
+
+    def test_raised_means_lower_number(self):
+        """Verify that raised priority means lower sequence number."""
+        pattern = PriorityPattern([{"type": "raised"}])
+
+        # Unbreak Now! (0) is higher priority than Normal (3)
+        transactions = [
+            {
+                "oldValue": "Normal",
+                "newValue": "Unbreak Now!",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "Unbreak Now!") is True
+
+    def test_lowered_means_higher_number(self):
+        """Verify that lowered priority means higher sequence number."""
+        pattern = PriorityPattern([{"type": "lowered"}])
+
+        # Wishlist (5) is lower priority than Normal (3)
+        transactions = [
+            {
+                "oldValue": "Normal",
+                "newValue": "Wishlist",
+                "dateCreated": 1234567890
+            }
+        ]
+
+        assert pattern.matches(transactions, "Wishlist") is True


### PR DESCRIPTION
## Overview

This PR adds comprehensive priority-based filtering for Maniphest tasks and restructures the output format to provide clearer separation between current state, history, and filter metadata.

## Key Features

### 🎯 Priority Filtering

Filter tasks based on priority changes over time, complementing the existing column transition filtering.

**Supported patterns:**
- `from:PRIORITY[:direction]` - Task changed from a priority (optionally with raised/lowered direction)
- `to:PRIORITY` - Task changed to a priority
- `in:PRIORITY` - Task is currently at a priority
- `been:PRIORITY` - Task was at a priority at any point in history
- `never:PRIORITY` - Task was never at a priority
- `raised` - Task had any priority increase
- `lowered` - Task had any priority decrease

**Examples:**

```bash
# Find tasks that were escalated to "Unbreak Now!" from Normal priority
phabfive maniphest search "My Project" --priority="from:Normal:raised"

# Find tasks currently at High priority
phabfive maniphest search "My Project" --priority="in:High"

# Find tasks that were ever at "Unbreak Now!" priority
phabfive maniphest search "My Project" --priority="been:Unbreak Now!"

# Combine with column filters - tasks moved forward from "Up Next" that were at Normal
phabfive maniphest search '*' \
  --column='from:Up Next:forward' \
  --priority='been:Normal' \
  --show-history \
  --show-metadata
```

### 📊 Restructured Output Format

The task output is now organized into three clear sections:

**1. Task** - Current state snapshot
```yaml
Task:
  Name: '[FEATURE] Improved error diagnostics'
  Created: 2025-10-01T17:21:56
  Modified: 2025-10-24T08:44:53
  Status: Open
  Priority: Unbreak Now!
  Description: |
    > Enhanced error reporting
  Boards:
    Development:
      Column: Up Next
    GUNNAR-Core:
      Column: In Review
```

**2. History** - Transition timeline (only shown with `--show-history`)
```yaml
History:
  Priority:
    - "2025-10-01T17:21:56 [↓] Triage → Normal"
    - "2025-10-23T12:55:59 [↑] Normal → Unbreak Now!"
  Boards:
    Development:
      Transitions:
        - "2025-10-14T10:52:33 [→] Backlog → In Review"
        - "2025-10-14T14:31:40 [←] In Review → Up Next"
```

**3. Metadata** - Filter match information (only shown with `--show-metadata`)
```yaml
Metadata:
  MatchedBoards: ['Development', 'GUNNAR-Core']
  MatchedPriority: true
```

### 🔍 Filter Debugging with `--show-metadata`

New flag to help debug complex filter combinations by showing exactly which boards and priorities matched your filters.

```bash
phabfive maniphest search '*' \
  --column='from:Up Next:forward' \
  --priority='been:Normal' \
  --show-metadata
```

This shows:
- **MatchedBoards**: Which board(s) satisfied the `--column` filter
- **MatchedPriority**: Whether the task matched the `--priority` filter

### 🔄 Explicit History Display

History is now only shown when explicitly requested with `--show-history`, not auto-enabled by filters. This improves performance for quick filtering operations.

```bash
# Fast: Filter only, no history fetching
phabfive maniphest search "My Project" --column="in:Done"

# Detailed: Include transition history
phabfive maniphest search "My Project" --column="in:Done" --show-history
```

## Technical Changes

### New Files
- `phabfive/priority_transitions.py` - Priority filtering logic with pattern matching
- `tests/test_priority_transitions.py` - Comprehensive test suite (51 tests)

### Modified Files
- `phabfive/cli.py` - Added `--priority`, `--show-metadata` flags; removed deprecated `--show-transitions`
- `phabfive/maniphest.py` - Restructured output, priority filtering integration, alphabetical board sorting
- `docs/maniphest-cli.md` - Comprehensive documentation for new features
- `tests/test_maniphest.py` - Updated for new method signatures

### Breaking Changes

1. **Removed `--show-transitions` flag** (use `--show-history` instead)
2. **History no longer auto-enabled** - must explicitly use `--show-history`
3. **Output format changed** - Tasks now use nested Task/History/Metadata structure

## Use Cases

### Track Priority Escalations
```bash
# Find all tasks that were raised to Unbreak Now!
phabfive maniphest search '*' --priority='to:Unbreak Now!' --show-history
```

### Audit Workflow Compliance
```bash
# Tasks completed without going through review
phabfive maniphest search "Product" \
  --column="in:Done+never:In Review" \
  --show-history
```

### Debug Complex Filters
```bash
# See exactly why each task matched
phabfive maniphest search "Backend" \
  --column="from:In Progress:forward" \
  --priority="raised" \
  --show-metadata
```

### Sprint Analysis
```bash
# High-priority tasks completed in last 14 days
phabfive maniphest search "Sprint 42" \
  --column="to:Done" \
  --priority="in:High,in:Unbreak Now!" \
  --updated-after=14 \
  --show-history
```