### PR TITLE
🔧 Fix logging stream configuration for stderr

### DIFF
--- a/phabfive/__init__.py
+++ b/phabfive/__init__.py
@@ -39,7 +39,7 @@ def init_logging(log_level):
                 "class": "logging.StreamHandler",
                 "level": log_level,
                 "formatter": "simple",
-                "stream": "ext://sys.stderr",
+                "stream": sys.stderr,
             },
         },
         "formatters": {


### PR DESCRIPTION
• Updated stream handler to use `sys.stderr` directly instead of string reference
• Improved log output reliability by ensuring correct stderr stream configuration