### PR TITLE
Add status filtering and transaction consolidation

### DIFF
--- a/phabfive/status_transitions.py
+++ b/phabfive/status_transitions.py
@@ -1,0 +1,442 @@
+# -*- coding: utf-8 -*-
+
+# python std lib
+import logging
+
+# phabfive imports
+from phabfive.exceptions import PhabfiveException
+
+log = logging.getLogger(__name__)
+
+# Fallback status ordering for comparison and workflow progression
+# Lower number = earlier in the workflow
+# Used to determine if status was "raised" (progressed forward) or "lowered" (moved backward)
+# This is only used if the API call to maniphest.querystatuses fails
+FALLBACK_STATUS_ORDER = {
+    "open": 0,
+    "blocked": 1,
+    "wontfix": 2,
+    "invalid": 3,
+    "duplicate": 4,
+    "resolved": 5,
+}
+
+
+def _build_status_order_from_api(api_response):
+    """
+    Build status order mapping from API response.
+
+    The maniphest.querystatuses API returns:
+    - openStatuses: list of open status keys
+    - closedStatuses: dict of closed status values
+    - statusMap: dict mapping status keys to display names
+
+    Parameters
+    ----------
+    api_response : dict
+        Response from maniphest.querystatuses API
+
+    Returns
+    -------
+    dict
+        Mapping of status name (lowercase) to order number
+    """
+    if not api_response:
+        return FALLBACK_STATUS_ORDER
+
+    order_map = {}
+
+    # Extract status information from API response
+    open_status_keys = api_response.get("openStatuses", [])
+    closed_status_values = api_response.get("closedStatuses", {})
+    status_map = api_response.get("statusMap", {})
+
+    # Build order: open statuses first (lower numbers), then closed statuses
+    current_order = 0
+
+    # Add open statuses
+    for status_key in open_status_keys:
+        status_name = status_map.get(status_key, status_key)
+        order_map[status_name.lower()] = current_order
+        current_order += 1
+
+    # Add closed statuses
+    for status_key in closed_status_values.values():
+        status_name = status_map.get(status_key, status_key)
+        order_map[status_name.lower()] = current_order
+        current_order += 1
+
+    return order_map
+
+
+def get_status_order(status_name, api_response=None):
+    """
+    Get the numeric order of a status for comparison.
+
+    Parameters
+    ----------
+    status_name : str
+        Status name (case-insensitive)
+    api_response : dict, optional
+        Full response from maniphest.querystatuses API.
+        If not provided, uses fallback ordering.
+
+    Returns
+    -------
+    int or None
+        Status order number, or None if not found
+    """
+    if not status_name:
+        return None
+
+    # Build order map from API response if provided
+    if api_response:
+        order_map = _build_status_order_from_api(api_response)
+    else:
+        order_map = FALLBACK_STATUS_ORDER
+
+    return order_map.get(status_name.lower())
+
+
+class StatusPattern:
+    """
+    Represents a single status pattern with AND conditions.
+
+    A pattern can have multiple conditions that must all match (AND logic).
+    Multiple patterns can be combined with OR logic.
+    """
+
+    def __init__(self, conditions, api_response=None):
+        """
+        Parameters
+        ----------
+        conditions : list
+            List of condition dicts, each with keys like:
+            {"type": "from", "status": "Open", "direction": "raised"}
+        api_response : dict, optional
+            Full response from maniphest.querystatuses API for ordering
+        """
+        self.conditions = conditions
+        self.api_response = api_response
+
+    def matches(self, status_transactions, current_status):
+        """
+        Check if all conditions in this pattern match (AND logic).
+
+        Parameters
+        ----------
+        status_transactions : list
+            List of status change transactions for a task
+        current_status : str or None
+            Current status name
+
+        Returns
+        -------
+        bool
+            True if all conditions match, False otherwise
+        """
+        # All conditions must match for the pattern to match
+        for condition in self.conditions:
+            if not self._matches_condition(
+                condition, status_transactions, current_status
+            ):
+                return False
+        return True
+
+    def _matches_condition(self, condition, status_transactions, current_status):
+        """Check if a single condition matches."""
+        condition_type = condition.get("type")
+
+        # Determine the match result based on condition type
+        if condition_type == "from":
+            result = self._matches_from(condition, status_transactions)
+        elif condition_type == "to":
+            result = self._matches_to(condition, status_transactions)
+        elif condition_type == "in":
+            result = self._matches_current(condition, current_status)
+        elif condition_type == "been":
+            result = self._matches_been(condition, status_transactions)
+        elif condition_type == "never":
+            result = self._matches_never(condition, status_transactions)
+        elif condition_type == "raised":
+            result = self._matches_raised(status_transactions)
+        elif condition_type == "lowered":
+            result = self._matches_lowered(status_transactions)
+        else:
+            log.warning(f"Unknown condition type: {condition_type}")
+            result = False
+
+        # Apply negation if the condition has the "not:" prefix
+        if condition.get("negated"):
+            result = not result
+
+        return result
+
+    def _matches_from(self, condition, status_transactions):
+        """Match 'from:STATUS[:direction]' pattern."""
+        target_status = condition.get("status")
+        direction = condition.get("direction")  # None, "raised", or "lowered"
+
+        for trans in status_transactions:
+            old_value = trans.get("oldValue")
+            new_value = trans.get("newValue")
+
+            if old_value is None or new_value is None:
+                continue
+
+            # Check if old status matches target (case-insensitive)
+            if old_value.lower() == target_status.lower():
+                # If no direction specified, it's a match
+                if direction is None:
+                    return True
+
+                # Check direction
+                old_order = get_status_order(old_value, self.api_response)
+                new_order = get_status_order(new_value, self.api_response)
+
+                if old_order is not None and new_order is not None:
+                    if direction == "raised" and new_order > old_order:
+                        return True
+                    elif direction == "lowered" and new_order < old_order:
+                        return True
+
+        return False
+
+    def _matches_to(self, condition, status_transactions):
+        """Match 'to:STATUS' pattern."""
+        target_status = condition.get("status")
+
+        for trans in status_transactions:
+            new_value = trans.get("newValue")
+
+            if new_value is None:
+                continue
+
+            if new_value.lower() == target_status.lower():
+                return True
+
+        return False
+
+    def _matches_current(self, condition, current_status):
+        """Match 'in:STATUS' pattern."""
+        target_status = condition.get("status")
+        if not current_status:
+            return False
+        return current_status.lower() == target_status.lower()
+
+    def _matches_been(self, condition, status_transactions):
+        """Match 'been:STATUS' pattern - task was at status at any point."""
+        target_status = condition.get("status")
+
+        for trans in status_transactions:
+            old_value = trans.get("oldValue")
+            new_value = trans.get("newValue")
+
+            # Check both old and new values
+            for value in [old_value, new_value]:
+                if value and value.lower() == target_status.lower():
+                    return True
+
+        return False
+
+    def _matches_never(self, condition, status_transactions):
+        """Match 'never:STATUS' pattern - task was never at status."""
+        target_status = condition.get("status")
+
+        for trans in status_transactions:
+            old_value = trans.get("oldValue")
+            new_value = trans.get("newValue")
+
+            # Check both old and new values
+            for value in [old_value, new_value]:
+                if value and value.lower() == target_status.lower():
+                    return False  # Found the status, so it's not "never"
+
+        return True  # Never found the status
+
+    def _matches_raised(self, status_transactions):
+        """Match 'raised' pattern - status progressed forward (higher number = further along)."""
+        for trans in status_transactions:
+            old_value = trans.get("oldValue")
+            new_value = trans.get("newValue")
+
+            if old_value is None or new_value is None:
+                continue
+
+            old_order = get_status_order(old_value, self.api_response)
+            new_order = get_status_order(new_value, self.api_response)
+
+            if old_order is not None and new_order is not None:
+                if new_order > old_order:  # Higher number = further along
+                    return True
+
+        return False
+
+    def _matches_lowered(self, status_transactions):
+        """Match 'lowered' pattern - status moved backward (lower number = earlier stage)."""
+        for trans in status_transactions:
+            old_value = trans.get("oldValue")
+            new_value = trans.get("newValue")
+
+            if old_value is None or new_value is None:
+                continue
+
+            old_order = get_status_order(old_value, self.api_response)
+            new_order = get_status_order(new_value, self.api_response)
+
+            if old_order is not None and new_order is not None:
+                if new_order < old_order:  # Lower number = earlier stage
+                    return True
+
+        return False
+
+
+def _parse_single_condition(condition_str):
+    """
+    Parse a single condition string.
+
+    Parameters
+    ----------
+    condition_str : str
+        Condition like "from:Open:raised", "in:Resolved", "raised", "lowered"
+        Can be prefixed with "not:" to negate: "not:in:Open", "not:raised"
+
+    Returns
+    -------
+    dict
+        Condition dict with keys like {"type": "from", "status": "Open", "direction": "raised"}
+        May include {"negated": True} if prefixed with "not:"
+
+    Raises
+    ------
+    PhabfiveException
+        If condition syntax is invalid
+    """
+    condition_str = condition_str.strip()
+
+    # Check for not: prefix
+    negated = False
+    if condition_str.startswith("not:"):
+        negated = True
+        condition_str = condition_str[4:].strip()  # Strip "not:" prefix
+
+    # Special keywords without parameters
+    if condition_str == "raised":
+        result = {"type": "raised"}
+        if negated:
+            result["negated"] = True
+        return result
+    elif condition_str == "lowered":
+        result = {"type": "lowered"}
+        if negated:
+            result["negated"] = True
+        return result
+
+    # Patterns with parameters: type:value or type:value:direction
+    if ":" not in condition_str:
+        raise PhabfiveException(f"Invalid status condition syntax: '{condition_str}'")
+
+    parts = condition_str.split(":", 2)  # Split into max 3 parts
+    condition_type = parts[0].strip()
+
+    if condition_type not in ["from", "to", "in", "been", "never"]:
+        raise PhabfiveException(
+            f"Invalid status condition type: '{condition_type}'. "
+            f"Valid types: from, to, in, been, never, raised, lowered"
+        )
+
+    if len(parts) < 2:
+        raise PhabfiveException(f"Missing status name for condition: '{condition_str}'")
+
+    status_name = parts[1].strip()
+    if not status_name:
+        raise PhabfiveException(f"Empty status name in condition: '{condition_str}'")
+
+    result = {"type": condition_type, "status": status_name}
+
+    # Handle optional direction for 'from' patterns
+    if len(parts) == 3:
+        if condition_type != "from":
+            raise PhabfiveException(
+                f"Direction modifier only allowed for 'from' patterns, got: '{condition_str}'"
+            )
+        direction = parts[2].strip()
+        if direction not in ["raised", "lowered"]:
+            raise PhabfiveException(
+                f"Invalid direction: '{direction}'. Must be 'raised' or 'lowered'"
+            )
+        result["direction"] = direction
+
+    # Add negated flag if not: prefix was present
+    if negated:
+        result["negated"] = True
+
+    return result
+
+
+def parse_status_patterns(patterns_str, api_response=None):
+    """
+    Parse status pattern string into list of StatusPattern objects.
+
+    Supports:
+    - Comma (,) for OR logic between patterns
+    - Plus (+) for AND logic within a pattern
+
+    Parameters
+    ----------
+    patterns_str : str
+        Pattern string like "from:Open:raised+in:Resolved,to:Closed"
+    api_response : dict, optional
+        Full response from maniphest.querystatuses API for ordering
+
+    Returns
+    -------
+    list
+        List of StatusPattern objects
+
+    Raises
+    ------
+    PhabfiveException
+        If pattern syntax is invalid
+
+    Examples
+    --------
+    >>> parse_status_patterns("from:Open:raised")
+    [StatusPattern([{"type": "from", "status": "Open", "direction": "raised"}])]
+
+    >>> parse_status_patterns("from:Open+in:Resolved,to:Closed")
+    [StatusPattern([from:Open, in:Resolved]), StatusPattern([to:Closed])]
+    """
+    if not patterns_str or not patterns_str.strip():
+        raise PhabfiveException("Empty status pattern")
+
+    patterns = []
+
+    # Split by comma for OR groups
+    or_groups = patterns_str.split(",")
+
+    for or_group in or_groups:
+        or_group = or_group.strip()
+        if not or_group:
+            continue
+
+        conditions = []
+
+        # Split by plus for AND conditions
+        and_parts = or_group.split("+")
+
+        for and_part in and_parts:
+            and_part = and_part.strip()
+            if not and_part:
+                continue
+
+            condition = _parse_single_condition(and_part)
+            conditions.append(condition)
+
+        if conditions:
+            patterns.append(StatusPattern(conditions, api_response))
+
+    if not patterns:
+        raise PhabfiveException("No valid status patterns found")
+
+    return patterns

--- a/tests/test_status_transitions.py
+++ b/tests/test_status_transitions.py
@@ -1,0 +1,344 @@
+# -*- coding: utf-8 -*-
+
+# 3rd party imports
+import pytest
+
+# phabfive imports
+from phabfive.status_transitions import (
+    StatusPattern,
+    _parse_single_condition,
+    parse_status_patterns,
+    get_status_order,
+)
+from phabfive.exceptions import PhabfiveException
+
+
+class TestGetStatusOrder:
+    def test_open(self):
+        assert get_status_order("Open") == 0
+
+    def test_blocked(self):
+        assert get_status_order("Blocked") == 1
+
+    def test_wontfix(self):
+        assert get_status_order("Wontfix") == 2
+
+    def test_invalid(self):
+        assert get_status_order("Invalid") == 3
+
+    def test_duplicate(self):
+        assert get_status_order("Duplicate") == 4
+
+    def test_resolved(self):
+        assert get_status_order("Resolved") == 5
+
+    def test_case_insensitive(self):
+        assert get_status_order("OPEN") == 0
+        assert get_status_order("blocked") == 1
+        assert get_status_order("ReSOlvEd") == 5
+
+    def test_unknown_status(self):
+        assert get_status_order("Unknown") is None
+
+    def test_none_input(self):
+        assert get_status_order(None) is None
+
+    def test_empty_string(self):
+        assert get_status_order("") is None
+
+
+class TestParseSingleCondition:
+    def test_parse_raised(self):
+        result = _parse_single_condition("raised")
+        assert result == {"type": "raised"}
+
+    def test_parse_lowered(self):
+        result = _parse_single_condition("lowered")
+        assert result == {"type": "lowered"}
+
+    def test_parse_from_simple(self):
+        result = _parse_single_condition("from:Open")
+        assert result == {"type": "from", "status": "Open"}
+
+    def test_parse_from_with_raised(self):
+        result = _parse_single_condition("from:Open:raised")
+        assert result == {"type": "from", "status": "Open", "direction": "raised"}
+
+    def test_parse_from_with_lowered(self):
+        result = _parse_single_condition("from:Resolved:lowered")
+        assert result == {"type": "from", "status": "Resolved", "direction": "lowered"}
+
+    def test_parse_to(self):
+        result = _parse_single_condition("to:Resolved")
+        assert result == {"type": "to", "status": "Resolved"}
+
+    def test_parse_in(self):
+        result = _parse_single_condition("in:Open")
+        assert result == {"type": "in", "status": "Open"}
+
+    def test_parse_been(self):
+        result = _parse_single_condition("been:Resolved")
+        assert result == {"type": "been", "status": "Resolved"}
+
+    def test_parse_never(self):
+        result = _parse_single_condition("never:Resolved")
+        assert result == {"type": "never", "status": "Resolved"}
+
+    def test_invalid_type(self):
+        with pytest.raises(PhabfiveException) as exc:
+            _parse_single_condition("invalid:Open")
+        assert "Invalid status condition type" in str(exc.value)
+
+    def test_missing_colon(self):
+        with pytest.raises(PhabfiveException) as exc:
+            _parse_single_condition("notavalidpattern")
+        assert "Invalid status condition syntax" in str(exc.value)
+
+    def test_empty_status_name(self):
+        with pytest.raises(PhabfiveException) as exc:
+            _parse_single_condition("from:")
+        assert "Empty status name" in str(exc.value)
+
+    def test_direction_on_non_from(self):
+        with pytest.raises(PhabfiveException) as exc:
+            _parse_single_condition("to:Open:raised")
+        assert "Direction modifier only allowed for 'from' patterns" in str(exc.value)
+
+    def test_invalid_direction(self):
+        with pytest.raises(PhabfiveException) as exc:
+            _parse_single_condition("from:Open:invalid")
+        assert "Invalid direction" in str(exc.value)
+
+    def test_parse_not_in(self):
+        result = _parse_single_condition("not:in:Open")
+        assert result == {"type": "in", "status": "Open", "negated": True}
+
+    def test_parse_not_from(self):
+        result = _parse_single_condition("not:from:Resolved")
+        assert result == {"type": "from", "status": "Resolved", "negated": True}
+
+    def test_parse_not_from_with_direction(self):
+        result = _parse_single_condition("not:from:Open:raised")
+        assert result == {"type": "from", "status": "Open", "direction": "raised", "negated": True}
+
+    def test_parse_not_been(self):
+        result = _parse_single_condition("not:been:Resolved")
+        assert result == {"type": "been", "status": "Resolved", "negated": True}
+
+    def test_parse_not_raised(self):
+        result = _parse_single_condition("not:raised")
+        assert result == {"type": "raised", "negated": True}
+
+    def test_parse_not_lowered(self):
+        result = _parse_single_condition("not:lowered")
+        assert result == {"type": "lowered", "negated": True}
+
+
+class TestParseStatusPatterns:
+    def test_single_simple_pattern(self):
+        patterns = parse_status_patterns("raised")
+        assert len(patterns) == 1
+        assert len(patterns[0].conditions) == 1
+        assert patterns[0].conditions[0]["type"] == "raised"
+
+    def test_single_from_pattern(self):
+        patterns = parse_status_patterns("from:Open:raised")
+        assert len(patterns) == 1
+        assert patterns[0].conditions[0] == {
+            "type": "from",
+            "status": "Open",
+            "direction": "raised",
+        }
+
+    def test_or_patterns_comma(self):
+        patterns = parse_status_patterns("in:Open,in:Resolved")
+        assert len(patterns) == 2
+        assert patterns[0].conditions[0] == {"type": "in", "status": "Open"}
+        assert patterns[1].conditions[0] == {"type": "in", "status": "Resolved"}
+
+    def test_and_conditions_plus(self):
+        patterns = parse_status_patterns("from:Open+in:Resolved")
+        assert len(patterns) == 1
+        assert len(patterns[0].conditions) == 2
+        assert patterns[0].conditions[0] == {"type": "from", "status": "Open"}
+        assert patterns[0].conditions[1] == {"type": "in", "status": "Resolved"}
+
+    def test_complex_pattern(self):
+        patterns = parse_status_patterns("from:Open:raised+in:Resolved,to:Wontfix")
+        assert len(patterns) == 2
+        # First pattern: AND conditions
+        assert len(patterns[0].conditions) == 2
+        assert patterns[0].conditions[0] == {
+            "type": "from",
+            "status": "Open",
+            "direction": "raised",
+        }
+        assert patterns[0].conditions[1] == {"type": "in", "status": "Resolved"}
+        # Second pattern
+        assert len(patterns[1].conditions) == 1
+        assert patterns[1].conditions[0] == {"type": "to", "status": "Wontfix"}
+
+    def test_empty_pattern(self):
+        with pytest.raises(PhabfiveException) as exc:
+            parse_status_patterns("")
+        assert "Empty status pattern" in str(exc.value)
+
+    def test_whitespace_only_pattern(self):
+        with pytest.raises(PhabfiveException) as exc:
+            parse_status_patterns("   ")
+        assert "Empty status pattern" in str(exc.value)
+
+
+class TestStatusPatternMatching:
+    def test_matches_in_current_status(self):
+        """Test 'in:STATUS' pattern matches current status"""
+        pattern = StatusPattern([{"type": "in", "status": "Open"}])
+
+        transactions = []
+        current_status = "Open"
+
+        assert pattern.matches(transactions, current_status) is True
+
+    def test_matches_in_different_status(self):
+        """Test 'in:STATUS' pattern doesn't match different status"""
+        pattern = StatusPattern([{"type": "in", "status": "Resolved"}])
+
+        transactions = []
+        current_status = "Open"
+
+        assert pattern.matches(transactions, current_status) is False
+
+    def test_matches_from_status(self):
+        """Test 'from:STATUS' pattern matches transition from that status"""
+        pattern = StatusPattern([{"type": "from", "status": "Open"}])
+
+        transactions = [
+            {"oldValue": "Open", "newValue": "Resolved", "dateCreated": 1234567890}
+        ]
+        current_status = "Resolved"
+
+        assert pattern.matches(transactions, current_status) is True
+
+    def test_matches_to_status(self):
+        """Test 'to:STATUS' pattern matches transition to that status"""
+        pattern = StatusPattern([{"type": "to", "status": "Resolved"}])
+
+        transactions = [
+            {"oldValue": "Open", "newValue": "Resolved", "dateCreated": 1234567890}
+        ]
+        current_status = "Resolved"
+
+        assert pattern.matches(transactions, current_status) is True
+
+    def test_matches_been_status(self):
+        """Test 'been:STATUS' pattern matches any occurrence of status"""
+        pattern = StatusPattern([{"type": "been", "status": "Open"}])
+
+        transactions = [
+            {"oldValue": "Open", "newValue": "Blocked", "dateCreated": 1234567890},
+            {"oldValue": "Blocked", "newValue": "Resolved", "dateCreated": 1234567900}
+        ]
+        current_status = "Resolved"
+
+        assert pattern.matches(transactions, current_status) is True
+
+    def test_matches_never_status(self):
+        """Test 'never:STATUS' pattern matches when status never occurred"""
+        pattern = StatusPattern([{"type": "never", "status": "Wontfix"}])
+
+        transactions = [
+            {"oldValue": "Open", "newValue": "Resolved", "dateCreated": 1234567890}
+        ]
+        current_status = "Resolved"
+
+        assert pattern.matches(transactions, current_status) is True
+
+    def test_matches_raised(self):
+        """Test 'raised' pattern matches status progression"""
+        pattern = StatusPattern([{"type": "raised"}])
+
+        transactions = [
+            {"oldValue": "Open", "newValue": "Resolved", "dateCreated": 1234567890}
+        ]
+        current_status = "Resolved"
+
+        assert pattern.matches(transactions, current_status) is True
+
+    def test_matches_lowered(self):
+        """Test 'lowered' pattern matches status regression"""
+        pattern = StatusPattern([{"type": "lowered"}])
+
+        transactions = [
+            {"oldValue": "Resolved", "newValue": "Open", "dateCreated": 1234567890}
+        ]
+        current_status = "Open"
+
+        assert pattern.matches(transactions, current_status) is True
+
+    def test_matches_not_in(self):
+        """Test 'not:in:STATUS' pattern negates the match"""
+        pattern = StatusPattern([{"type": "in", "status": "Open", "negated": True}])
+
+        transactions = []
+        current_status = "Resolved"
+
+        assert pattern.matches(transactions, current_status) is True
+
+    def test_matches_and_conditions(self):
+        """Test multiple AND conditions must all match"""
+        pattern = StatusPattern([
+            {"type": "been", "status": "Open"},
+            {"type": "in", "status": "Resolved"}
+        ])
+
+        transactions = [
+            {"oldValue": "Open", "newValue": "Resolved", "dateCreated": 1234567890}
+        ]
+        current_status = "Resolved"
+
+        assert pattern.matches(transactions, current_status) is True
+
+    def test_matches_and_conditions_fail(self):
+        """Test multiple AND conditions fail if any doesn't match"""
+        pattern = StatusPattern([
+            {"type": "been", "status": "Open"},
+            {"type": "in", "status": "Wontfix"}
+        ])
+
+        transactions = [
+            {"oldValue": "Open", "newValue": "Resolved", "dateCreated": 1234567890}
+        ]
+        current_status = "Resolved"
+
+        assert pattern.matches(transactions, current_status) is False
+
+    def test_matches_from_with_raised_direction(self):
+        """Test 'from:STATUS:raised' matches status change with progression"""
+        pattern = StatusPattern([{"type": "from", "status": "Open", "direction": "raised"}])
+
+        transactions = [
+            {"oldValue": "Open", "newValue": "Resolved", "dateCreated": 1234567890}
+        ]
+        current_status = "Resolved"
+
+        assert pattern.matches(transactions, current_status) is True
+
+    def test_matches_from_with_lowered_direction(self):
+        """Test 'from:STATUS:lowered' matches status change with regression"""
+        pattern = StatusPattern([{"type": "from", "status": "Resolved", "direction": "lowered"}])
+
+        transactions = [
+            {"oldValue": "Resolved", "newValue": "Open", "dateCreated": 1234567890}
+        ]
+        current_status = "Open"
+
+        assert pattern.matches(transactions, current_status) is True
+
+    def test_case_insensitive_matching(self):
+        """Test status matching is case-insensitive"""
+        pattern = StatusPattern([{"type": "in", "status": "OPEN"}])
+
+        transactions = []
+        current_status = "open"
+
+        assert pattern.matches(transactions, current_status) is True

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.0
-envlist = py{310,311,312,313},flake8,coverage,mkdocs
+envlist = py{310,311,312,313,314},flake8,coverage,mkdocs
 basepython =
     py310: python3.10
     py311: python3.11


### PR DESCRIPTION
Add comprehensive status filtering support and consolidate transaction fetching:

- docs/maniphest-cli.md: Added a new 'Status Filtering' section with pattern syntax, examples, combining with other filters, negation, and metadata notes. Also updated examples to include --status usage and metadata.

- phabfive/cli.py: Added --status option help text and examples in CLI usage, imported parse_status_patterns, parse status patterns from args, and wired status_patterns into task_search calls. Also updated --show-history description to include status history and show-metadata to indicate status matching.

- phabfive/status_transitions.py: New module implementing StatusPattern parsing and matching, status ordering map, helper functions get_status_order, _parse_single_condition, parse_status_patterns, and StatusPattern class with matching logic for from/to/in/been/never/raised/lowered and negation support.

- phabfive/maniphest.py: Reorganized imports, added transaction consolidation method _fetch_all_transactions to fetch columns/priority/status in one call, updated matching functions to accept pre-fetched transactions (_task_matches_priority_patterns, added _task_matches_status_patterns), updated _task_matches_any_pattern and task_search to use consolidated transactions, added status_transitions_map and matching_status_map handling, updated history and metadata builders to include status history and matched status booleans, and refactored history fetching to use consolidated method.

- tests/test_status_transitions.py: Added comprehensive unit tests for status parsing and matching including orders, parsing errors, pattern combinations, and matching behavior.

- tox.ini: Added py314 to envlist.

These changes implement status transition filtering end-to-end: CLI, parsing, matching, history display, tests, and docs. Tests and new module are isolated; transaction fetching consolidation touches maniphest to reduce API calls and integrate status handling.