### PR TITLE
🚀 feat: Add advanced project filtering with AND/OR logic

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Phabfive currently supports the following Phabricator/Phorge applications:
 - **Diffusion** - List repositories, get branches, clone URIs, add repositories, manage URIs
 - **Paste** - List, get, and add code pastes
 - **User** - Get information about the logged-in user
-- **Maniphest** - Add comments, show task details, create tasks from templates, and search with advanced transition filtering
+- **Maniphest** - Add comments, show task details, create tasks from templates, and search with advanced project filtering and transition filtering
 
 ## Getting Started
 

--- a/phabfive/project_filters.py
+++ b/phabfive/project_filters.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+
+# python std lib
+import fnmatch
+import logging
+
+# phabfive imports
+from phabfive.exceptions import PhabfiveException
+
+log = logging.getLogger(__name__)
+
+
+class ProjectPattern:
+    """
+    Represents a single project pattern with AND conditions.
+
+    A pattern can have multiple conditions that must all match (AND logic).
+    Multiple patterns can be combined with OR logic.
+
+    Each condition is a project name or wildcard pattern. A task matches
+    if it is assigned to all projects in the pattern (AND logic).
+    """
+
+    def __init__(self, project_names):
+        """
+        Parameters
+        ----------
+        project_names : list
+            List of project names or wildcard patterns that must all match (AND logic).
+            Examples: ["ProjectA"], ["ProjectA", "ProjectB"], ["Project*"]
+        """
+        self.project_names = project_names
+
+    def matches(self, task_project_names, resolved_projects_map):
+        """
+        Check if all conditions in this pattern match (AND logic).
+
+        A task matches if it belongs to all projects in this pattern.
+        Project names support wildcards using fnmatch.
+
+        Parameters
+        ----------
+        task_project_names : list
+            List of project names that this task belongs to
+        resolved_projects_map : dict
+            Mapping of resolved project patterns to PHIDs.
+            Example: {"ProjectA": "PHID-PROJ-abc", "ProjectB*": ["PHID-PROJ-xyz", ...]}
+
+        Returns
+        -------
+        bool
+            True if task belongs to all projects in this pattern, False otherwise
+        """
+        # All project conditions must match for the pattern to match
+        for project_pattern in self.project_names:
+            if not self._matches_project(
+                project_pattern, task_project_names, resolved_projects_map
+            ):
+                return False
+        return True
+
+    def _matches_project(
+        self, project_pattern, task_project_names, resolved_projects_map
+    ):
+        """
+        Check if a task belongs to a project matching the given pattern.
+
+        Parameters
+        ----------
+        project_pattern : str
+            Project name or wildcard pattern (e.g., "ProjectA", "Project*")
+        task_project_names : list
+            List of project names the task belongs to
+        resolved_projects_map : dict
+            Mapping of resolved project patterns to PHIDs
+
+        Returns
+        -------
+        bool
+            True if task belongs to a project matching the pattern
+        """
+        # Check if pattern is a wildcard
+        has_wildcard = "*" in project_pattern
+
+        if has_wildcard:
+            # Check if task's projects match the wildcard pattern
+            for task_project in task_project_names:
+                if fnmatch.fnmatch(task_project.lower(), project_pattern.lower()):
+                    return True
+            return False
+        else:
+            # Exact match (case-insensitive)
+            project_pattern_lower = project_pattern.lower()
+            for task_project in task_project_names:
+                if task_project.lower() == project_pattern_lower:
+                    return True
+            return False
+
+
+def _parse_single_project(project_str):
+    """
+    Parse a single project name or wildcard pattern.
+
+    Parameters
+    ----------
+    project_str : str
+        Project name or wildcard pattern (e.g., "ProjectA", "Project*")
+
+    Returns
+    -------
+    str
+        Project name or pattern
+
+    Raises
+    ------
+    PhabfiveException
+        If project name is empty
+    """
+    project_str = project_str.strip()
+
+    if not project_str:
+        raise PhabfiveException("Empty project name in pattern")
+
+    return project_str
+
+
+def parse_project_patterns(patterns_str):
+    """
+    Parse project pattern string into list of ProjectPattern objects.
+
+    Supports:
+    - Comma (,) for OR logic between patterns
+    - Plus (+) for AND logic within a pattern
+    - Wildcard (*) for pattern matching
+
+    Parameters
+    ----------
+    patterns_str : str
+        Pattern string like "ProjectA,ProjectB*" or "ProjectA+ProjectB"
+
+    Returns
+    -------
+    list
+        List of ProjectPattern objects
+
+    Raises
+    ------
+    PhabfiveException
+        If pattern syntax is invalid
+
+    Examples
+    --------
+    >>> parse_project_patterns("ProjectA")
+    [ProjectPattern(["ProjectA"])]
+
+    >>> parse_project_patterns("ProjectA,ProjectB*")
+    [ProjectPattern(["ProjectA"]), ProjectPattern(["ProjectB*"])]
+
+    >>> parse_project_patterns("ProjectA+ProjectB")
+    [ProjectPattern(["ProjectA", "ProjectB"])]
+    """
+    if not patterns_str or not patterns_str.strip():
+        raise PhabfiveException("Empty project pattern")
+
+    patterns = []
+
+    # Split by comma for OR groups
+    or_groups = patterns_str.split(",")
+
+    for or_group in or_groups:
+        or_group = or_group.strip()
+        if not or_group:
+            continue
+
+        project_names = []
+
+        # Split by plus for AND conditions
+        and_parts = or_group.split("+")
+
+        for and_part in and_parts:
+            and_part = and_part.strip()
+            if not and_part:
+                continue
+
+            project_name = _parse_single_project(and_part)
+            project_names.append(project_name)
+
+        if project_names:
+            patterns.append(ProjectPattern(project_names))
+
+    if not patterns:
+        raise PhabfiveException("No valid project patterns found")
+
+    return patterns

--- a/tests/test_project_filters.py
+++ b/tests/test_project_filters.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+
+# 3rd party imports
+import pytest
+
+from phabfive.exceptions import PhabfiveException
+
+# phabfive imports
+from phabfive.project_filters import (
+    ProjectPattern,
+    _parse_single_project,
+    parse_project_patterns,
+)
+
+
+class TestParseSingleProject:
+    def test_parse_simple_project(self):
+        result = _parse_single_project("ProjectA")
+        assert result == "ProjectA"
+
+    def test_parse_project_with_wildcard(self):
+        result = _parse_single_project("Project*")
+        assert result == "Project*"
+
+    def test_parse_project_with_leading_wildcard(self):
+        result = _parse_single_project("*Project")
+        assert result == "*Project"
+
+    def test_parse_project_with_both_wildcards(self):
+        result = _parse_single_project("*Project*")
+        assert result == "*Project*"
+
+    def test_parse_empty_string(self):
+        with pytest.raises(PhabfiveException) as exc:
+            _parse_single_project("")
+        assert "Empty project name" in str(exc.value)
+
+    def test_parse_whitespace_only(self):
+        with pytest.raises(PhabfiveException) as exc:
+            _parse_single_project("   ")
+        assert "Empty project name" in str(exc.value)
+
+    def test_parse_with_leading_trailing_whitespace(self):
+        result = _parse_single_project("  ProjectA  ")
+        assert result == "ProjectA"
+
+
+class TestProjectPatternMatches:
+    def test_exact_match_single_project_with_spaces(self):
+        """Test matching project names with spaces"""
+        pattern = ProjectPattern(["Project A"])
+        assert pattern.matches(["Project A"], {}) is True
+
+    def test_exact_match_single_project(self):
+        pattern = ProjectPattern(["ProjectA"])
+        assert pattern.matches(["ProjectA"], {}) is True
+
+    def test_exact_match_case_insensitive(self):
+        pattern = ProjectPattern(["ProjectA"])
+        assert pattern.matches(["projecta"], {}) is True
+        assert pattern.matches(["PROJECTA"], {}) is True
+
+    def test_no_match_different_project(self):
+        pattern = ProjectPattern(["ProjectA"])
+        assert pattern.matches(["ProjectB"], {}) is False
+
+    def test_match_in_multiple_projects(self):
+        pattern = ProjectPattern(["ProjectA"])
+        assert pattern.matches(["ProjectA", "ProjectB"], {}) is True
+
+    def test_wildcard_prefix_match(self):
+        pattern = ProjectPattern(["Project*"])
+        assert pattern.matches(["ProjectA"], {}) is True
+        assert pattern.matches(["ProjectB"], {}) is True
+        assert pattern.matches(["Project"], {}) is True
+
+    def test_wildcard_prefix_no_match(self):
+        pattern = ProjectPattern(["Project*"])
+        assert pattern.matches(["MyProject"], {}) is False
+        assert pattern.matches(["Legacy"], {}) is False
+
+    def test_wildcard_suffix_match(self):
+        pattern = ProjectPattern(["*Project"])
+        assert pattern.matches(["MyProject"], {}) is True
+        assert pattern.matches(["LegacyProject"], {}) is True
+        assert pattern.matches(["Project"], {}) is True
+
+    def test_wildcard_suffix_no_match(self):
+        pattern = ProjectPattern(["*Project"])
+        assert pattern.matches(["ProjectA"], {}) is False
+        assert pattern.matches(["MyProjects"], {}) is False
+
+    def test_wildcard_contains_match(self):
+        pattern = ProjectPattern(["*Test*"])
+        assert pattern.matches(["TestProject"], {}) is True
+        assert pattern.matches(["MyTestProject"], {}) is True
+        assert pattern.matches(["TestingCode"], {}) is True
+
+    def test_wildcard_contains_no_match(self):
+        pattern = ProjectPattern(["*Test*"])
+        assert pattern.matches(["ProjectA"], {}) is False
+        assert pattern.matches(["Code"], {}) is False
+
+    def test_and_logic_both_match(self):
+        """Test AND logic: both projects must match"""
+        pattern = ProjectPattern(["ProjectA", "ProjectB"])
+        assert pattern.matches(["ProjectA", "ProjectB"], {}) is True
+
+    def test_and_logic_first_matches_second_doesnt(self):
+        """Test AND logic: first matches but second doesn't"""
+        pattern = ProjectPattern(["ProjectA", "ProjectB"])
+        assert pattern.matches(["ProjectA", "ProjectC"], {}) is False
+
+    def test_and_logic_neither_match(self):
+        """Test AND logic: neither project matches"""
+        pattern = ProjectPattern(["ProjectA", "ProjectB"])
+        assert pattern.matches(["ProjectC", "ProjectD"], {}) is False
+
+    def test_and_logic_with_wildcard(self):
+        """Test AND logic with wildcard and exact match"""
+        pattern = ProjectPattern(["Project*", "LegacyA"])
+        assert pattern.matches(["ProjectA", "LegacyA"], {}) is True
+        assert pattern.matches(["ProjectA"], {}) is False
+        assert pattern.matches(["LegacyA"], {}) is False
+
+    def test_empty_project_names(self):
+        """Task with no projects should not match"""
+        pattern = ProjectPattern(["ProjectA"])
+        assert pattern.matches([], {}) is False
+
+    def test_case_insensitive_wildcard(self):
+        pattern = ProjectPattern(["project*"])
+        assert pattern.matches(["PROJECTA"], {}) is True
+        assert pattern.matches(["ProjectB"], {}) is True
+
+
+class TestParseProjectPatterns:
+    def test_single_project(self):
+        patterns = parse_project_patterns("ProjectA")
+        assert len(patterns) == 1
+        assert patterns[0].project_names == ["ProjectA"]
+
+    def test_comma_separated_projects_or_logic(self):
+        """Comma creates OR between patterns"""
+        patterns = parse_project_patterns("ProjectA,ProjectB")
+        assert len(patterns) == 2
+        assert patterns[0].project_names == ["ProjectA"]
+        assert patterns[1].project_names == ["ProjectB"]
+
+    def test_plus_separated_projects_and_logic(self):
+        """Plus creates AND within a pattern"""
+        patterns = parse_project_patterns("ProjectA+ProjectB")
+        assert len(patterns) == 1
+        assert patterns[0].project_names == ["ProjectA", "ProjectB"]
+
+    def test_mixed_comma_and_plus(self):
+        """Mixed: (ProjectA AND ProjectB) OR (ProjectC AND ProjectD)"""
+        patterns = parse_project_patterns("ProjectA+ProjectB,ProjectC+ProjectD")
+        assert len(patterns) == 2
+        assert patterns[0].project_names == ["ProjectA", "ProjectB"]
+        assert patterns[1].project_names == ["ProjectC", "ProjectD"]
+
+    def test_wildcard_with_comma(self):
+        patterns = parse_project_patterns("Project*,Legacy*")
+        assert len(patterns) == 2
+        assert patterns[0].project_names == ["Project*"]
+        assert patterns[1].project_names == ["Legacy*"]
+
+    def test_wildcard_with_plus(self):
+        patterns = parse_project_patterns("Project*+Legacy*")
+        assert len(patterns) == 1
+        assert patterns[0].project_names == ["Project*", "Legacy*"]
+
+    def test_empty_string(self):
+        with pytest.raises(PhabfiveException) as exc:
+            parse_project_patterns("")
+        assert "Empty project pattern" in str(exc.value)
+
+    def test_whitespace_only(self):
+        with pytest.raises(PhabfiveException) as exc:
+            parse_project_patterns("   ")
+        assert "Empty project pattern" in str(exc.value)
+
+    def test_trailing_comma(self):
+        """Trailing comma creates empty group, which is skipped"""
+        patterns = parse_project_patterns("ProjectA,")
+        assert len(patterns) == 1
+        assert patterns[0].project_names == ["ProjectA"]
+
+    def test_trailing_plus(self):
+        """Trailing plus creates empty part, which is skipped"""
+        patterns = parse_project_patterns("ProjectA+")
+        assert len(patterns) == 1
+        assert patterns[0].project_names == ["ProjectA"]
+
+    def test_leading_comma(self):
+        """Leading comma creates empty group, which is skipped"""
+        patterns = parse_project_patterns(",ProjectA")
+        assert len(patterns) == 1
+        assert patterns[0].project_names == ["ProjectA"]
+
+    def test_multiple_commas(self):
+        """Multiple commas create empty groups"""
+        patterns = parse_project_patterns("ProjectA,,ProjectB")
+        assert len(patterns) == 2
+        assert patterns[0].project_names == ["ProjectA"]
+        assert patterns[1].project_names == ["ProjectB"]
+
+    def test_whitespace_around_operators(self):
+        """Whitespace around operators should be trimmed"""
+        patterns = parse_project_patterns("ProjectA , ProjectB + ProjectC")
+        assert len(patterns) == 2
+        assert patterns[0].project_names == ["ProjectA"]
+        assert patterns[1].project_names == ["ProjectB", "ProjectC"]
+
+    def test_complex_pattern(self):
+        """Complex pattern: (A AND B) OR (C*) OR (D AND E*)"""
+        patterns = parse_project_patterns("ProjectA+ProjectB,Project*,ProjectD+Legacy*")
+        assert len(patterns) == 3
+        assert patterns[0].project_names == ["ProjectA", "ProjectB"]
+        assert patterns[1].project_names == ["Project*"]
+        assert patterns[2].project_names == ["ProjectD", "Legacy*"]
+
+    def test_case_sensitive_parsing_but_used_case_insensitive(self):
+        """Project names are stored as-is but matched case-insensitive"""
+        patterns = parse_project_patterns("ProjectA,projectb")
+        assert len(patterns) == 2
+        assert patterns[0].project_names == ["ProjectA"]
+        assert patterns[1].project_names == ["projectb"]
+
+    def test_project_names_with_spaces(self):
+        """Project names can contain spaces"""
+        patterns = parse_project_patterns("Project A,Project B")
+        assert len(patterns) == 2
+        assert patterns[0].project_names == ["Project A"]
+        assert patterns[1].project_names == ["Project B"]
+
+    def test_project_names_with_spaces_and_and_logic(self):
+        """Project names with spaces and AND logic"""
+        patterns = parse_project_patterns("Project A+Project B")
+        assert len(patterns) == 1
+        assert patterns[0].project_names == ["Project A", "Project B"]
+
+    def test_project_names_with_spaces_mixed_operators(self):
+        """Complex pattern with spaces: (Project A AND Project B) OR (Legacy Project C)"""
+        patterns = parse_project_patterns("Project A+Project B,Legacy Project C")
+        assert len(patterns) == 2
+        assert patterns[0].project_names == ["Project A", "Project B"]
+        assert patterns[1].project_names == ["Legacy Project C"]
+
+
+class TestProjectPatternIntegration:
+    """Integration tests for complete filtering scenarios"""
+
+    def test_or_logic_first_pattern_matches(self):
+        """OR logic: first pattern matches"""
+        patterns = parse_project_patterns("ProjectA,ProjectB")
+        task_projects = ["ProjectA"]
+        # First pattern matches
+        assert patterns[0].matches(task_projects, {}) is True
+        # Check any pattern matches (simulating filter logic)
+        assert any(p.matches(task_projects, {}) for p in patterns) is True
+
+    def test_or_logic_second_pattern_matches(self):
+        """OR logic: second pattern matches"""
+        patterns = parse_project_patterns("ProjectA,ProjectB")
+        task_projects = ["ProjectB"]
+        # First pattern doesn't match
+        assert patterns[0].matches(task_projects, {}) is False
+        # Second pattern matches
+        assert patterns[1].matches(task_projects, {}) is True
+        # Check any pattern matches
+        assert any(p.matches(task_projects, {}) for p in patterns) is True
+
+    def test_or_logic_no_pattern_matches(self):
+        """OR logic: no pattern matches"""
+        patterns = parse_project_patterns("ProjectA,ProjectB")
+        task_projects = ["ProjectC"]
+        # Neither pattern matches
+        assert all(not p.matches(task_projects, {}) for p in patterns) is True
+        # Check any pattern matches
+        assert any(p.matches(task_projects, {}) for p in patterns) is False
+
+    def test_and_logic_all_conditions_match(self):
+        """AND logic: all conditions in pattern match"""
+        patterns = parse_project_patterns("ProjectA+ProjectB")
+        task_projects = ["ProjectA", "ProjectB"]
+        # Pattern matches
+        assert patterns[0].matches(task_projects, {}) is True
+
+    def test_and_logic_partial_conditions_match(self):
+        """AND logic: only some conditions match"""
+        patterns = parse_project_patterns("ProjectA+ProjectB")
+        task_projects = ["ProjectA"]
+        # Pattern doesn't match because ProjectB is missing
+        assert patterns[0].matches(task_projects, {}) is False
+
+    def test_wildcard_or_logic(self):
+        """Wildcard with OR logic"""
+        patterns = parse_project_patterns("Project*,Legacy*")
+        # Matches first wildcard
+        assert any(p.matches(["ProjectA"], {}) for p in patterns) is True
+        # Matches second wildcard
+        assert any(p.matches(["LegacyA"], {}) for p in patterns) is True
+        # Matches neither wildcard
+        assert any(p.matches(["CustomA"], {}) for p in patterns) is False


### PR DESCRIPTION
## Overview

- Implemented advanced project filtering in Maniphest search
- Added support for complex project pattern matching with AND/OR logic
- Introduced wildcard support for project names
- Created new `ProjectPattern` class for pattern resolution
- Enhanced project filtering with more granular control
- Improved logging and error handling for project patterns

## Key Features

Users can now filter tasks using advanced project selection criteria:
- AND logic: "ProjectA+ProjectB"
- OR logic: "ProjectA,ProjectB"
- Wildcard matching for project names