### PR TITLE
🔖 Bump version to 0.5.0-rc0 for upcoming release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "phabfive"
-version = "0.4.0"
+version = "0.5.0-rc0"
 description = "A command line tool to interact with Phabricator"
 readme = "README.md"
 license = {text = "Apache License 2.0"}


### PR DESCRIPTION
Prepare for the next release candidate by incrementing the
version number. This indicates a new pre-release version with
potential new features or improvements.