### PR TITLE
Support Multiple Project Hashtags in Maniphest Search

### DIFF
--- a/tests/test_maniphest.py
+++ b/tests/test_maniphest.py
@@ -954,11 +954,15 @@ class TestYAMLOutput:
         # Mock the phab API
         maniphest.phab = MagicMock()
 
-        # Mock project search to return a project
-        maniphest.phab.project.search.return_value = {
-            "data": [{"phid": "PHID-PROJ-123", "fields": {"name": "Test Project"}}],
-            "cursor": {"after": None},
+        # Mock project.query to return a project with slugs
+        mock_project_result = MagicMock()
+        mock_project_result.get.return_value = {
+            "PHID-PROJ-123": {
+                "name": "Test Project",
+                "slugs": ["test-project", "test_project"],
+            }
         }
+        maniphest.phab.project.query.return_value = mock_project_result
 
         # Mock maniphest search with tasks containing special YAML characters
         mock_response = MagicMock()


### PR DESCRIPTION
Fixes #102

## Changes

### Core Functionality
- **Match all project hashtags**: `maniphest search` now matches against all configured hashtags/slugs for a project, not just the primary name
- **Switched to `project.query` API**: Uses `project.query()` instead of `project.search()` to access the full `slugs` array
- **Deduplication**: Automatically prevents duplicate results when multiple hashtags of the same project match a wildcard pattern

### User Experience
- **Case-insensitive matching**: Works with any casing (e.g., `devex`, `DevEx`, `DEVEX`)
- **Better error messages**: Suggestions now show the matched slug in parentheses:
  ```
  ERROR - Project 'devx' not found. Did you mean: Developer-Experience (devex)?
  ```
- **Primary name always searchable**: Can search by project name OR any hashtag

### Bug Fixes
- Fixed KeyError in CLI when running `maniphest search` (changed to use `.get()` instead of direct dict access)

## Examples

```bash
# Before: Only primary name worked
$ phabfive maniphest search 'developer-experience'  # ✓
$ phabfive maniphest search 'devex'                 # ✗ Error

# After: All hashtags work
$ phabfive maniphest search 'developer-experience'  # ✓
$ phabfive maniphest search 'devex'                 # ✓
$ phabfive maniphest search 'dev-exp'               # ✓

# Clear suggestions with matched slugs
$ phabfive maniphest search 'devx'
ERROR - Project 'devx' not found. Did you mean: Developer-Experience (devex)?
```

## Technical Details

- Uses `project.query()` API which returns all slugs in a `slugs` array
- Maintains backward compatibility - all existing functionality works unchanged
