### PR TITLE
Align maniphest show and maniphest search Output

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -498,7 +498,7 @@ wheels = [
 
 [[package]]
 name = "phabfive"
-version = "0.4.0"
+version = "0.5.0rc0"
 source = { editable = "." }
 dependencies = [
     { name = "anyconfig" },


### PR DESCRIPTION
Fixes #101

## Changes

### Core Functionality
- **Shared display logic**: Extracted ~80 lines of duplicate YAML formatting code into a reusable `_format_and_display_tasks()` method
- **Unified output format**: Both `maniphest show` and `maniphest search` now produce identical YAML output
- **New `task_show()` method**: Uses modern `maniphest.search` API instead of deprecated `maniphest.info` for consistency

### Command-Line Interface
- **Added `--show-history` flag**: Display transition history for columns, priority, and status (both commands)
- **Added `--show-metadata` flag**: Display metadata about filter matches (both commands)
- **Backward compatibility**: `--all` flag now maps to `--show-history` for consistency
- **Legacy support**: `--pp` flag preserved for users who need the old pretty-print format

## Examples

```bash
# Before: Inconsistent flags and output formats
$ phabfive maniphest show T123 --all        # Plain text with transitions
$ phabfive maniphest search Project         # YAML format

# After: Consistent flags and output
$ phabfive maniphest show T123              # YAML format (basic)
$ phabfive maniphest show T123 --show-history       # YAML with history
$ phabfive maniphest show T123 --show-metadata      # YAML with metadata
$ phabfive maniphest search Project --show-history  # Same YAML format

# Backward compatibility maintained
$ phabfive maniphest show T123 --all        # YAML with history (same as --show-history)
$ phabfive maniphest show T123 --pp         # Legacy pretty-print format
```

## Sample Output

Both commands now produce identical structured YAML:

```yaml
- Link: http://phorge.domain.tld/T1
  Task:
    Name: '[EPIC] GUNNAR Gen1 Chip Architecture Design'
    Status: Open
    Priority: High
    Created: '2025-10-01T17:21:53'
    Modified: '2025-10-01T17:21:54'
    Description: |-
      Complete initial architecture design...
  Boards:
    Architecture:
      Column: Backlog
    GUNNAR-Core:
      Column: Backlog
  History:  # Only with --show-history or --all
    Priority:
    - 2025-10-01T17:21:53 [↓] Triage → High
  Metadata:  # Only with --show-metadata
    MatchedBoards: []
    MatchedPriority: false
    MatchedStatus: false
```

## Technical Details

- **Zero code duplication**: Display logic lives in single `_format_and_display_tasks()` method
- **Consistent API usage**: Both commands now use `maniphest.search` API for modern feature support
- **Maintains backward compatibility**: Old `maniphest.info` API still used by `--pp` flag
- **Modular design**: Easy to add new display sections (just update shared method)

## Benefits

1. **Consistent user experience** - Same flags and output format across commands
2. **Reduced maintenance** - Display logic in one place, easier to fix bugs and add features
3. **Better structure** - YAML output is parseable and more machine-friendly
4. **Backward compatible** - Existing workflows continue to work with minor format improvements
5. **Future-proof** - New features (like `--show-history`) work in both commands automatically
