### PR TITLE
fix(maniphest): Display comments in task show output

### DIFF
--- a/phabfive/maniphest.py
+++ b/phabfive/maniphest.py
@@ -2173,6 +2173,20 @@ class Maniphest(Phabfive):
                     for trans in hist_value:
                         console.print(f"      - {trans}")
 
+        # Print Comments section
+        comments = task_dict.get("Comments", [])
+        if comments:
+            console.print("  Comments:")
+            for comment in comments:
+                if isinstance(comment, PreservedScalarString) or "\n" in str(comment):
+                    # Multi-line comment
+                    lines = str(comment).splitlines()
+                    console.print(f"    - {lines[0]}")
+                    for line in lines[1:]:
+                        console.print(f"      {line}")
+                else:
+                    console.print(f"    - {comment}")
+
         # Print Metadata section
         if metadata:
             console.print("  Metadata:")
@@ -2265,6 +2279,20 @@ class Maniphest(Phabfive):
                     for trans in hist_value:
                         hist_type_branch.add(trans)
 
+        # Add Comments section
+        comments = task_dict.get("Comments", [])
+        if comments:
+            comments_branch = tree.add("Comments")
+            for comment in comments:
+                if isinstance(comment, PreservedScalarString) or "\n" in str(comment):
+                    # Truncate multi-line comments in tree view
+                    first_line = str(comment).split("\n")[0]
+                    if len(first_line) > 60:
+                        first_line = first_line[:57] + "..."
+                    comments_branch.add(first_line)
+                else:
+                    comments_branch.add(str(comment))
+
         # Add Metadata section
         if metadata:
             meta_branch = tree.add("Metadata")
@@ -2328,6 +2356,17 @@ class Maniphest(Phabfive):
         # Add History section if present
         if task_dict.get("History"):
             output["History"] = task_dict["History"]
+
+        # Add Comments section if present
+        if task_dict.get("Comments"):
+            # Convert PreservedScalarString to plain strings for strict YAML
+            comments = []
+            for comment in task_dict["Comments"]:
+                if isinstance(comment, PreservedScalarString):
+                    comments.append(str(comment))
+                else:
+                    comments.append(comment)
+            output["Comments"] = comments
 
         # Add Metadata section if present
         if task_dict.get("Metadata"):


### PR DESCRIPTION
## Summary

- Fix `--show-comments` flag not displaying comments in task output
- The flag was fetching comment data correctly but the display methods never rendered the Comments section
- Add Comments display code to all three output formats (rich, tree, strict)

This is a fix for an oversight in #118.

## Test plan

- [x] Run `phabfive T66 --show-comments` and verify comments are displayed
- [x] Test with `--format=tree` to verify tree output shows comments
- [x] Test with `--format=strict` to verify strict YAML output includes comments
- [x] Run `uv run tox --skip-missing-interpreters` - all 257 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)