### PR TITLE
Add support for Arcanist .arcrc configuration files

### DIFF
--- a/phabfive/core.py
+++ b/phabfive/core.py
@@ -268,6 +268,9 @@ class Phabfive:
         """
         Check that a file has secure permissions (not readable by group/others).
 
+        Note: This check is skipped on Windows, which uses ACLs instead of
+        Unix-style permissions.
+
         Parameters
         ----------
         file_path : str
@@ -278,6 +281,10 @@ class Phabfive:
         PhabfiveConfigException
             If the file has insecure permissions (group or others can read)
         """
+        # Skip permission check on Windows (uses ACLs, not Unix permissions)
+        if os.name == "nt":
+            return
+
         if not os.path.exists(file_path):
             return
 

--- a/tests/test_arcrc.py
+++ b/tests/test_arcrc.py
@@ -12,8 +12,18 @@ from phabfive.core import Phabfive
 from phabfive.exceptions import PhabfiveConfigException
 
 
+# Skip marker for tests that require Unix-style permissions
+skip_on_windows = pytest.mark.skipif(
+    os.name == "nt", reason="Windows uses ACLs, not Unix permissions"
+)
+
+
 class TestCheckSecurePermissions:
-    """Tests for the _check_secure_permissions method."""
+    """Tests for the _check_secure_permissions method.
+
+    Note: Most tests in this class are skipped on Windows because Windows
+    uses ACLs instead of Unix-style permissions.
+    """
 
     def setup_method(self):
         """Create a Phabfive instance without initialization for testing."""
@@ -25,6 +35,7 @@ class TestCheckSecurePermissions:
         # Should not raise
         self.phabfive._check_secure_permissions(str(nonexistent))
 
+    @skip_on_windows
     def test_secure_permissions_600(self, tmp_path):
         """Test that 0600 permissions pass."""
         config_file = tmp_path / "config.yaml"
@@ -33,6 +44,7 @@ class TestCheckSecurePermissions:
         # Should not raise
         self.phabfive._check_secure_permissions(str(config_file))
 
+    @skip_on_windows
     def test_secure_permissions_400(self, tmp_path):
         """Test that 0400 permissions pass."""
         config_file = tmp_path / "config.yaml"
@@ -41,6 +53,7 @@ class TestCheckSecurePermissions:
         # Should not raise
         self.phabfive._check_secure_permissions(str(config_file))
 
+    @skip_on_windows
     def test_insecure_permissions_group_read(self, tmp_path):
         """Test that group readable (0640) raises error."""
         config_file = tmp_path / "config.yaml"
@@ -54,6 +67,7 @@ class TestCheckSecurePermissions:
         assert "0o640" in str(exc_info.value)
         assert "chmod 600" in str(exc_info.value)
 
+    @skip_on_windows
     def test_insecure_permissions_world_read(self, tmp_path):
         """Test that world readable (0644) raises error."""
         config_file = tmp_path / "config.yaml"
@@ -66,6 +80,7 @@ class TestCheckSecurePermissions:
         assert "insecure permissions" in str(exc_info.value)
         assert "0o644" in str(exc_info.value)
 
+    @skip_on_windows
     def test_insecure_permissions_group_write(self, tmp_path):
         """Test that group writable (0620) raises error."""
         config_file = tmp_path / "config.yaml"
@@ -77,6 +92,7 @@ class TestCheckSecurePermissions:
 
         assert "insecure permissions" in str(exc_info.value)
 
+    @skip_on_windows
     def test_insecure_permissions_world_execute(self, tmp_path):
         """Test that world executable (0701) raises error."""
         config_file = tmp_path / "config.yaml"
@@ -103,6 +119,7 @@ class TestLoadArcrc:
             result = self.phabfive._load_arcrc({})
         assert result == {}
 
+    @skip_on_windows
     def test_arcrc_insecure_permissions_group_readable(self, tmp_path):
         """Test that .arcrc with group read permission raises error."""
         arcrc_path = tmp_path / ".arcrc"
@@ -116,6 +133,7 @@ class TestLoadArcrc:
         assert "insecure permissions" in str(exc_info.value)
         assert "chmod 600" in str(exc_info.value)
 
+    @skip_on_windows
     def test_arcrc_insecure_permissions_world_readable(self, tmp_path):
         """Test that .arcrc with world read permission raises error."""
         arcrc_path = tmp_path / ".arcrc"


### PR DESCRIPTION
## Summary

- Add support for reading credentials from Arcanist's `~/.arcrc` file, making it easier for existing Arcanist users to get started with phabfive
- Add security checks to ensure user configuration files have secure permissions (0600) before reading them
- Support `config.default` field in `.arcrc` to select the default host when multiple hosts are configured
- Support multiple hosts in `.arcrc` by requiring `PHAB_URL` to be set when more than one host is configured and no default is specified

## Features

- **`.arcrc` support**: Automatically reads `PHAB_URL` and `PHAB_TOKEN` from `~/.arcrc` if present
- **Multi-host handling**: 
  - Single host → uses both URL and token automatically
  - Multiple hosts with `config.default` → uses the default host
  - Multiple hosts without default → requires `PHAB_URL` to select which host
- **Priority order**:
  1. `PHAB_URL` from env/config (highest)
  2. `config.default` from `.arcrc`
  3. Single host in `.arcrc` (auto-select)
  4. Multiple hosts without default (error with list)
- **Permission checks**: Validates that `~/.config/phabfive.yaml`, `~/.config/phabfive.d/*.yaml`, and `~/.arcrc` have secure permissions (not readable by group/others)
- **URL normalization**: Handles various URL formats including those without `/api/` suffix

## Test plan

- [x] Added 28 tests covering:
  - Permission checking (`_check_secure_permissions`)
  - `.arcrc` loading with various permission modes
  - Single and multiple host scenarios
  - `config.default` handling
  - URL matching with trailing slashes and ports
  - Legacy certificate format handling
- [x] All 290 tests pass

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)