### PR TITLE
Handle KeyboardInterrupt gracefully in CLI

### DIFF
--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -773,5 +773,9 @@ def cli_entrypoint():
 
     try:
         sys.exit(run(cli_args, sub_args))
+    except KeyboardInterrupt:
+        # Handle Ctrl+C gracefully
+        print("\nOperation cancelled by user.", file=sys.stderr)
+        sys.exit(130)  # Standard Unix exit code for SIGINT (128 + 2)
     except Exception:
         raise


### PR DESCRIPTION
## Summary

- Add exception handling for `KeyboardInterrupt` (Ctrl+C) to provide a clean exit instead of displaying a full traceback
- Improves user experience when cancelling long-running operations like network requests

## Changes

- Catch `KeyboardInterrupt` in `cli_entrypoint()` function
- Display "Operation cancelled by user." message to stderr
- Exit with code 130 (standard Unix convention: 128 + SIGINT signal number 2)

## Before

```
^CTraceback (most recent call last):
  File "/home/nn/code/github.com/dynamist/phabfive/.venv/bin/phabfive", line 10, in <module>
    sys.exit(cli_entrypoint())
  [... 50+ lines of traceback ...]
KeyboardInterrupt
```

## After

```
^C
Operation cancelled by user.
```
Exit code: 130

## Test Plan

- [x] Tested with mock KeyboardInterrupt simulation
- [x] Verified clean output message
- [x] Verified exit code 130
- [x] Confirmed other exceptions still propagate normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)