### PR TITLE
Add --created-before and --updated-before filters to maniphest search

### DIFF
--- a/docs/maniphest-cli.md
+++ b/docs/maniphest-cli.md
@@ -215,7 +215,7 @@ phabfive maniphest search "migration" --tag "Database" --column="in:In Progress"
 ```
 
 !!! important
-    **Validation:** At least one filter is required (text query, --tag, --created-after, --updated-after, --column, --priority, or --status) to prevent accidentally querying all tasks.
+    **Validation:** At least one filter is required (text query, --tag, --created-after, --created-before, --updated-after, --updated-before, --column, --priority, or --status) to prevent accidentally querying all tasks.
 
 ### Advanced Project Filtering
 
@@ -375,7 +375,7 @@ phabfive maniphest search --tag "Product*+Security" \
 **Performance Considerations**:
 - Specific project names are faster than wildcards
 - Wildcards like `"*"` (all projects) may take longer for large instances
-- Combine with date filters (`--created-after`, `--updated-after`) to narrow results
+- Combine with date filters (`--created-after`, `--created-before`, `--updated-after`, `--updated-before`) to narrow results
 
 **Debugging Patterns**:
 If a pattern doesn't return expected results:
@@ -402,18 +402,37 @@ If a pattern doesn't return expected results:
 
 ### Date Filtering
 
-Filter tasks by creation or modification date:
+Filter tasks by creation or modification date using both "after" (within the last N days) and "before" (more than N days ago) filters:
 
 ```bash
 # Tasks created in the last 7 days (in a specific project)
 phabfive maniphest search --tag "My Project" --created-after=7
 
+# Tasks created more than 30 days ago (older tasks)
+phabfive maniphest search --tag "My Project" --created-before=30
+
 # Tasks updated in the last 3 days (across all projects)
 phabfive maniphest search --updated-after=3
 
-# Combine both filters with free-text search
+# Tasks updated more than 7 days ago (stale tasks)
+phabfive maniphest search --tag "My Project" --updated-before=7
+
+# Combine both filters to create date ranges
+# Tasks created between 7 and 30 days ago
+phabfive maniphest search --tag "My Project" --created-after=30 --created-before=7
+
+# Combine with free-text search
 phabfive maniphest search "migration" --created-after=30 --updated-after=7
+
+# Find stale high-priority tasks
+phabfive maniphest search --tag "My Project" --updated-before=14 --priority="in:High"
 ```
+
+**Date Filter Options:**
+- `--created-after=N`: Tasks created within the last N days
+- `--created-before=N`: Tasks created more than N days ago
+- `--updated-after=N`: Tasks updated within the last N days
+- `--updated-before=N`: Tasks updated more than N days ago
 
 ## Filtering Tasks
 
@@ -931,7 +950,7 @@ phabfive maniphest search --tag "Sprint 42" \
 ### Performance
 
 - Filtering requires fetching task history, which may be slower for large result sets
-- Consider combining with date filters (`--created-after`, `--updated-after`) to narrow results
+- Consider combining with date filters (`--created-after`, `--created-before`, `--updated-after`, `--updated-before`) to narrow results
 - Use specific project names rather than wildcards when possible
 
 ### Debugging Patterns

--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -198,7 +198,9 @@ Options:
                           "*suffix" (ends with), "*contains*" (contains text).
                           Filter syntax: "ProjectA,ProjectB" (OR), "ProjectA+ProjectB" (AND).
     --created-after=N      Tasks created within the last N days
+    --created-before=N     Tasks created more than N days ago
     --updated-after=N      Tasks updated within the last N days
+    --updated-before=N     Tasks updated more than N days ago
     --column=PATTERNS      Filter tasks by column transitions (comma=OR, plus=AND).
                            Automatically displays transition history.
                              from:COLUMN[:direction]  - Moved from COLUMN
@@ -658,8 +660,14 @@ def run(cli_args, sub_args):
                     created_after = get_param(
                         "--created-after", yaml_params, "created-after"
                     )
+                    created_before = get_param(
+                        "--created-before", yaml_params, "created-before"
+                    )
                     updated_after = get_param(
                         "--updated-after", yaml_params, "updated-after"
+                    )
+                    updated_before = get_param(
+                        "--updated-before", yaml_params, "updated-before"
                     )
 
                     # Check if any search criteria provided, show usage if not
@@ -683,7 +691,9 @@ def run(cli_args, sub_args):
                         text_query=text_query,
                         tag=tag,
                         created_after=created_after,
+                        created_before=created_before,
                         updated_after=updated_after,
+                        updated_before=updated_before,
                         column_patterns=column_patterns,
                         priority_patterns=priority_patterns,
                         status_patterns=status_patterns,

--- a/phabfive/maniphest.py
+++ b/phabfive/maniphest.py
@@ -2502,7 +2502,9 @@ class Maniphest(Phabfive):
             "text_query",
             "tag",
             "created-after",
+            "created-before",
             "updated-after",
+            "updated-before",
             "column",
             "priority",
             "status",
@@ -2551,7 +2553,9 @@ class Maniphest(Phabfive):
         text_query=None,
         tag=None,
         created_after=None,
+        created_before=None,
         updated_after=None,
+        updated_before=None,
         column_patterns=None,
         priority_patterns=None,
         status_patterns=None,
@@ -2570,7 +2574,9 @@ class Maniphest(Phabfive):
                       Supports filter syntax: "ProjectA,ProjectB" (OR), "ProjectA+ProjectB" (AND)
                       If None, no project filtering is applied.
         created_after (int, optional): Number of days ago the task was created.
+        created_before (int, optional): Tasks created more than N days ago.
         updated_after (int, optional): Number of days ago the task was updated.
+        updated_before (int, optional): Tasks updated more than N days ago.
         column_patterns (list, optional): List of ColumnPattern objects to filter by.
                       Filters tasks based on column transitions (from, to, in, been, never, forward, backward).
         priority_patterns (list, optional): List of PriorityPattern objects to filter by.
@@ -2588,7 +2594,9 @@ class Maniphest(Phabfive):
                 text_query,
                 tag,
                 created_after,
+                created_before,
                 updated_after,
+                updated_before,
                 column_patterns,
                 priority_patterns,
                 status_patterns,
@@ -2600,11 +2608,17 @@ class Maniphest(Phabfive):
 
         # Convert date filters to Unix timestamps (preserve original day values for logging)
         created_after_days = created_after
+        created_before_days = created_before
         updated_after_days = updated_after
+        updated_before_days = updated_before
         if created_after:
             created_after = days_to_unix(created_after)
+        if created_before:
+            created_before = days_to_unix(created_before)
         if updated_after:
             updated_after = days_to_unix(updated_after)
+        if updated_before:
+            updated_before = days_to_unix(updated_before)
 
         project_patterns = None
         project_phids = []
@@ -2688,8 +2702,12 @@ class Maniphest(Phabfive):
 
             if created_after:
                 constraints["createdStart"] = int(created_after)
+            if created_before:
+                constraints["createdEnd"] = int(created_before)
             if updated_after:
                 constraints["modifiedStart"] = int(updated_after)
+            if updated_before:
+                constraints["modifiedEnd"] = int(updated_before)
 
             # Use pagination to fetch all tasks (API returns max 100 per page)
             result_data = []
@@ -2732,8 +2750,12 @@ class Maniphest(Phabfive):
 
                     if created_after:
                         constraints["createdStart"] = int(created_after)
+                    if created_before:
+                        constraints["createdEnd"] = int(created_before)
                     if updated_after:
                         constraints["modifiedStart"] = int(updated_after)
+                    if updated_before:
+                        constraints["modifiedEnd"] = int(updated_before)
 
                     # Use pagination for each project (API returns max 100 per page)
                     after = None
@@ -2777,8 +2799,12 @@ class Maniphest(Phabfive):
 
                 if created_after:
                     constraints["createdStart"] = int(created_after)
+                if created_before:
+                    constraints["createdEnd"] = int(created_before)
                 if updated_after:
                     constraints["modifiedStart"] = int(updated_after)
+                if updated_before:
+                    constraints["modifiedEnd"] = int(updated_before)
 
                 # Use pagination to fetch all tasks (API returns max 100 per page)
                 result_data = []
@@ -2843,8 +2869,12 @@ class Maniphest(Phabfive):
                 filter_desc.append(f"tag='{tag}'")
             if created_after:
                 filter_desc.append(f"created-after={created_after_days}d")
+            if created_before:
+                filter_desc.append(f"created-before={created_before_days}d")
             if updated_after:
                 filter_desc.append(f"updated-after={updated_after_days}d")
+            if updated_before:
+                filter_desc.append(f"updated-before={updated_before_days}d")
             if column_patterns:
                 col_strs = [str(p) for p in column_patterns]
                 filter_desc.append(f"column='{','.join(col_strs)}'")


### PR DESCRIPTION
## Summary

This PR adds support for filtering tasks created or updated **more than N days ago**, complementing the existing `--created-after` and `--updated-after` filters that find tasks within the last N days.

### New Filters

- `--created-before=N`: Tasks created more than N days ago
- `--updated-before=N`: Tasks updated more than N days ago

### Use Cases

These filters enable several useful queries:

- **Find stale tasks**: `--updated-before=14 --priority="in:High"` (high-priority tasks not updated in 2 weeks)
- **Date ranges**: Combine with "after" filters to create ranges (e.g., `--created-after=30 --created-before=7` for tasks created between 7-30 days ago)
- **Old tasks**: `--created-before=90` (tasks older than 3 months)

### Implementation Details

- Uses Phabricator API constraints `createdEnd` and `modifiedEnd`
- Follows the same pattern as existing `--created-after` and `--updated-after` filters
- Supports all search code paths (no tag, OR logic, AND logic)
- Includes YAML template support via `supported_params`
- Fully documented with examples in `docs/maniphest-cli.md`

### Changes

- **CLI** (`phabfive/cli.py`): Added options to help and parameter extraction
- **Core** (`phabfive/maniphest.py`): Added parameters to `task_search()` with Unix timestamp conversion and API constraint mapping
- **Docs** (`docs/maniphest-cli.md`): Added examples and updated all filter references

### Test Plan

Tested with:
```bash
# Find stale high-priority tasks
uv run phabfive maniphest search --tag '*' --updated-before=7

# Find old tasks
uv run phabfive maniphest search --tag '*' --created-before=30

# Complex query with multiple filters
uv run phabfive maniphest search --tag '*' --priority='in:High' \
  --status='not:in:Resolved' --column="not:in:Done" --updated-before=7
```

All filters work correctly and appear properly in filter descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)