### PR TITLE
Add time unit support for date filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ EOF
 phabfive passphrase K123
 phabfive paste list
 phabfive maniphest search "migration tasks" --tag myproject
-phabfive maniphest search --tag myproject --updated-after=7
+phabfive maniphest search --tag myproject --updated-after=1w
 ```
 
 ## Documentation

--- a/docs/maniphest-cli.md
+++ b/docs/maniphest-cli.md
@@ -143,7 +143,7 @@ Search for tasks by text in their title or description:
 phabfive maniphest search "Let's Encrypt"
 
 # Search for "OpenStack" with date filter
-phabfive maniphest search "OpenStack" --updated-after=7
+phabfive maniphest search "OpenStack" --updated-after=1w
 
 # Search for text within a specific project
 phabfive maniphest search "API error" --tag "Backend Team"
@@ -175,7 +175,7 @@ phabfive maniphest search --tag "ProjectA,ProjectB"
 phabfive maniphest search --tag "Team Alpha+Sprint 42"
 
 # Combine with date filters
-phabfive maniphest search --tag "Backend" --updated-after=7
+phabfive maniphest search --tag "Backend" --updated-after=1w
 ```
 
 !!! tip
@@ -211,7 +211,7 @@ phabfive maniphest search "kubernetes" --tag "Infrastructure"
 phabfive maniphest search "security" --tag "Backend*,Frontend*"
 
 # Text search with date and column filters
-phabfive maniphest search "migration" --tag "Database" --column="in:In Progress" --updated-after=14
+phabfive maniphest search "migration" --tag "Database" --column="in:In Progress" --updated-after=2w
 ```
 
 !!! important
@@ -346,7 +346,7 @@ Project patterns work seamlessly with other search filters:
 
 ```bash
 # Recent tasks in multiple projects
-phabfive maniphest search --tag "ProjectA,ProjectB" --updated-after=7
+phabfive maniphest search --tag "ProjectA,ProjectB" --updated-after=1w
 
 # Tasks in both team and sprint, currently in specific column
 phabfive maniphest search --tag "Backend+Sprint 42" --column="in:In Progress"
@@ -357,7 +357,7 @@ phabfive maniphest search --tag "Backend*" --priority="in:High"
 # Tasks at intersection of team and milestone, recently completed
 phabfive maniphest search --tag "API Team+Milestone 3" \
   --column="to:Done" \
-  --updated-after=14
+  --updated-after=2w
 
 # Security tasks across products that moved backward
 phabfive maniphest search --tag "Product*+Security" \
@@ -402,37 +402,49 @@ If a pattern doesn't return expected results:
 
 ### Date Filtering
 
-Filter tasks by creation or modification date using both "after" (within the last N days) and "before" (more than N days ago) filters:
+Filter tasks by creation or modification date using both "after" (within the last TIME) and "before" (more than TIME ago) filters. Time values support multiple units for convenience.
+
+**Supported Time Units:**
+- `h` - hours (e.g., `12h` = 12 hours)
+- `d` - days (e.g., `7d` = 7 days, or just `7` defaults to days)
+- `w` - weeks (e.g., `2w` = 2 weeks = 14 days)
+- `m` - months (e.g., `1m` = 1 month ≈ 30 days)
+- `y` - years (e.g., `1y` = 1 year ≈ 365 days)
 
 ```bash
-# Tasks created in the last 7 days (in a specific project)
-phabfive maniphest search --tag "My Project" --created-after=7
+# Tasks created in the last week (using time units)
+phabfive maniphest search --tag "My Project" --created-after=1w
 
-# Tasks created more than 30 days ago (older tasks)
-phabfive maniphest search --tag "My Project" --created-before=30
+# Tasks created more than a month ago (older tasks)
+phabfive maniphest search --tag "My Project" --created-before=1m
 
-# Tasks updated in the last 3 days (across all projects)
+# Tasks updated in the last 3 days (backward compatible)
 phabfive maniphest search --updated-after=3
 
-# Tasks updated more than 7 days ago (stale tasks)
-phabfive maniphest search --tag "My Project" --updated-before=7
+# Tasks updated more than 1 week ago (stale tasks)
+phabfive maniphest search --tag "My Project" --updated-before=1w
+
+# Tasks updated in the last 12 hours (recent activity)
+phabfive maniphest search --tag "My Project" --updated-after=12h
 
 # Combine both filters to create date ranges
-# Tasks created between 7 and 30 days ago
-phabfive maniphest search --tag "My Project" --created-after=30 --created-before=7
+# Tasks created between 1 week and 1 month ago
+phabfive maniphest search --tag "My Project" --created-after=1m --created-before=1w
 
 # Combine with free-text search
-phabfive maniphest search "migration" --created-after=30 --updated-after=7
+phabfive maniphest search "migration" --created-after=1m --updated-after=1w
 
-# Find stale high-priority tasks
-phabfive maniphest search --tag "My Project" --updated-before=14 --priority="in:High"
+# Find stale high-priority tasks (not updated in 2 weeks)
+phabfive maniphest search --tag "My Project" --updated-before=2w --priority="in:High"
 ```
 
 **Date Filter Options:**
-- `--created-after=N`: Tasks created within the last N days
-- `--created-before=N`: Tasks created more than N days ago
-- `--updated-after=N`: Tasks updated within the last N days
-- `--updated-before=N`: Tasks updated more than N days ago
+- `--created-after=TIME`: Tasks created within the last TIME (e.g., `1h`, `7d`, `2w`, `1m`, `1y`)
+- `--created-before=TIME`: Tasks created more than TIME ago (e.g., `1h`, `7d`, `2w`, `1m`, `1y`)
+- `--updated-after=TIME`: Tasks updated within the last TIME (e.g., `1h`, `7d`, `2w`, `1m`, `1y`)
+- `--updated-before=TIME`: Tasks updated more than TIME ago (e.g., `1h`, `7d`, `2w`, `1m`, `1y`)
+
+**Note:** Plain numbers (e.g., `7`) are interpreted as days for backward compatibility.
 
 ## Filtering Tasks
 

--- a/docs/search-templates.md
+++ b/docs/search-templates.md
@@ -63,8 +63,8 @@ search:
   status: "in:Open"
   column: "in:In Progress"
   priority: "in:High"
-  created-after: 7
-  updated-after: 7
+  created-after: "1w"  # Time units: h, d, w, m, y (or use numbers for days)
+  updated-after: "1w"
   show-history: true
   show-metadata: false
 
@@ -88,7 +88,7 @@ description: "What this search does"
 search:
   tag: "project-name"
   status: "in:Resolved"
-  updated-after: 7
+  updated-after: "1w"  # Can also use plain numbers: 7 (defaults to days)
 
 ---
 # Add more searches with --- separators
@@ -98,13 +98,19 @@ search:
 
 - `text_query`: Free-text search in task title/description
 - `tag`: Project/workboard filtering with wildcards and logic
-- `created-after`: Tasks created within N days
-- `updated-after`: Tasks updated within N days
+- `created-after`: Tasks created within TIME (e.g., `"1w"`, `"2m"`, or `7` for days)
+- `created-before`: Tasks created more than TIME ago (e.g., `"1w"`, `"2m"`, or `7` for days)
+- `updated-after`: Tasks updated within TIME (e.g., `"1w"`, `"2m"`, or `7` for days)
+- `updated-before`: Tasks updated more than TIME ago (e.g., `"1w"`, `"2m"`, or `7` for days)
 - `column`: Column transition patterns
 - `priority`: Priority transition patterns
 - `status`: Status transition patterns
 - `show-history`: Display transition history (true/false)
 - `show-metadata`: Display filter match metadata (true/false)
+
+**Time Unit Support:**
+All date filters support time units: `h` (hours), `d` (days), `w` (weeks), `m` (months), `y` (years).
+Examples: `"12h"`, `"1w"`, `"2m"`, `"1y"`. Plain numbers default to days.
 
 ## Creating Your Own Templates
 

--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -197,10 +197,10 @@ Options:
                           Supports: "*" (all projects), "prefix*" (starts with),
                           "*suffix" (ends with), "*contains*" (contains text).
                           Filter syntax: "ProjectA,ProjectB" (OR), "ProjectA+ProjectB" (AND).
-    --created-after=N      Tasks created within the last N days
-    --created-before=N     Tasks created more than N days ago
-    --updated-after=N      Tasks updated within the last N days
-    --updated-before=N     Tasks updated more than N days ago
+    --created-after=TIME   Tasks created within the last TIME (e.g., 1h, 7d, 2w, 1m, 1y)
+    --created-before=TIME  Tasks created more than TIME ago (e.g., 1h, 7d, 2w, 1m, 1y)
+    --updated-after=TIME   Tasks updated within the last TIME (e.g., 1h, 7d, 2w, 1m, 1y)
+    --updated-before=TIME  Tasks updated more than TIME ago (e.g., 1h, 7d, 2w, 1m, 1y)
     --column=PATTERNS      Filter tasks by column transitions (comma=OR, plus=AND).
                            Automatically displays transition history.
                              from:COLUMN[:direction]  - Moved from COLUMN
@@ -257,10 +257,11 @@ Examples:
 
     # Tag search (project/workboard filtering)
     phabfive maniphest search --tag Developer-Experience
-    phabfive maniphest search --tag Developer-Experience --updated-after 7
+    phabfive maniphest search --tag Developer-Experience --updated-after 1w
 
-    # Combined search
-    phabfive maniphest search OpenStack --tag System-Board --updated-after 7
+    # Combined search with time units
+    phabfive maniphest search OpenStack --tag System-Board --updated-after 2w
+    phabfive maniphest search --tag Backend --created-after 1m --updated-after 7d
 
     # Using YAML templates
     phabfive maniphest search --with templates/task-search/tasks-resolved-but-not-in-done.yaml


### PR DESCRIPTION
## Summary
Adds support for time units (h, d, w, m, y) to date filter flags, addressing #105.

## Changes

### Core Implementation
- **New function**: `parse_time_with_unit()` in `phabfive/maniphest.py` to parse time values with optional unit suffixes
- **Updated**: `task_search()` method to use the parser for all four date parameters:
  - `--created-after`
  - `--created-before`
  - `--updated-after`
  - `--updated-before`
- **Improved display**: Output now shows original time values with units (e.g., `created-after=1w` instead of `created-after=7d`)

### Supported Time Units
| Unit | Description | Example |
|------|-------------|---------|
| `h` | Hours | `12h` = 12 hours |
| `d` | Days | `7d` = 7 days |
| `w` | Weeks | `2w` = 14 days |
| `m` | Months | `1m` ≈ 30 days |
| `y` | Years | `1y` ≈ 365 days |

**Note**: Plain numbers (e.g., `7`) continue to work as days for backward compatibility.

### Testing
- ✅ Added 17 comprehensive tests covering:
  - All time units (h, d, w, m, y)
  - Backward compatibility with plain numbers
  - Error handling for invalid inputs
  - Edge cases (zero, negative, whitespace, case sensitivity)
- ✅ All 115 tests pass

### Documentation
- Updated CLI help text with time unit syntax
- Updated `docs/maniphest-cli.md` with comprehensive examples
- Updated `docs/search-templates.md` with YAML template examples
- Updated `README.md` examples

## Example Usage

```bash
# Before (only days)
phabfive maniphest search --tag Backend --updated-after=7

# After (with time units)
phabfive maniphest search --tag Backend --updated-after=1w
phabfive maniphest search --tag Project --created-after=2m --updated-after=1w
phabfive maniphest search --tag Team --updated-after=12h
```

### YAML Template Example
```yaml
search:
  tag: "My Project"
  created-after: "1w"   # or use plain numbers: 7
  updated-before: "2w"
```

## Benefits
- 🎯 No mental math needed to convert weeks/months/years to days
- 🔄 Fully backward compatible with existing scripts
- 📝 Clear, user-friendly syntax
- ✅ Comprehensive error messages for invalid formats
- 🧪 Well-tested with 100% test coverage

## Fixes
Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)