### PR TITLE
Add --assigned filter to maniphest search with OR logic support

### DIFF
--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -149,7 +149,7 @@ Usage:
     phabfive maniphest create --with=TEMPLATE [options]
 
 Arguments:
-    <title>              Task title (for CLI mode)
+    <title>                 Task title (for CLI mode)
 
 Options:
     --with=TEMPLATE         Load task creation template from YAML file (bulk mode)
@@ -189,17 +189,18 @@ Usage:
     phabfive maniphest search [<text_query>] [options]
 
 Arguments:
-     <text_query>         Optional free-text search in task title/description.
-                         If omitted, you must provide at least one filter option.
+     <text_query>          Optional free-text search in task title/description.
+                           If omitted, you must provide at least one filter option.
 
 Options:
-    --with=TEMPLATE      Load search parameters from a YAML template file.
-                          Command-line options will override YAML values.
+    --with=TEMPLATE        Load search parameters from a YAML template file.
+                           Command-line options will override YAML values.
     --tag=PATTERN          Filter by project/workboard tag (supports OR/AND logic and wildcards).
-                          Supports: "*" (all projects), "prefix*" (starts with),
-                          "*suffix" (ends with), "*contains*" (contains text).
-                          Filter syntax: "ProjectA,ProjectB" (OR), "ProjectA+ProjectB" (AND).
-    --assigned=USER        Filter by assignee. Use "@me" for tasks assigned to you.
+                           Supports: "*" (all projects), "prefix*" (starts with),
+                           "*suffix" (ends with), "*contains*" (contains text).
+                           Filter syntax: "ProjectA,ProjectB" (OR), "ProjectA+ProjectB" (AND).
+    --assigned=USER        Filter by assignee. Use "@me" for yourself, or provide username(s).
+                           Comma-separated for OR logic (e.g., @me,user1,user2).
     --created-after=TIME   Tasks created within the last TIME (e.g., 1h, 7d, 2w, 1m, 1y)
     --created-before=TIME  Tasks created more than TIME ago (e.g., 1h, 7d, 2w, 1m, 1y)
     --updated-after=TIME   Tasks updated within the last TIME (e.g., 1h, 7d, 2w, 1m, 1y)
@@ -249,9 +250,9 @@ Options:
                               from:Open:raised
                               not:in:Resolved+raised
                               in:Open,been:Resolved
-     --show-history         Display column, priority, and status transition history
-     --show-metadata        Display filter match metadata (which boards/priority/status matched)
-     -h, --help             Show this help message and exit
+     --show-history        Display column, priority, and status transition history
+     --show-metadata       Display filter match metadata (which boards/priority/status matched)
+     -h, --help            Show this help message and exit
 
 Examples:
     # Free-text search
@@ -262,9 +263,10 @@ Examples:
     phabfive maniphest search --tag Developer-Experience
     phabfive maniphest search --tag Developer-Experience --updated-after 1w
 
-    # Assigned to me
+    # Assigned to me or specific users
     phabfive maniphest search --assigned @me
     phabfive maniphest search --assigned @me --tag MyProject
+    phabfive maniphest search --assigned @me,user1 --tag dynatron --status 'not:in:Resolved'
 
     # Combined search with time units
     phabfive maniphest search OpenStack --tag System-Board --updated-after 2w

--- a/phabfive/maniphest.py
+++ b/phabfive/maniphest.py
@@ -2603,7 +2603,7 @@ class Maniphest(Phabfive):
                       Supports filter syntax: "ProjectA,ProjectB" (OR), "ProjectA+ProjectB" (AND)
                       If None, no project filtering is applied.
         assigned      (str, optional): Filter by assignee. Use "@me" to filter tasks assigned to you,
-                      or provide a username.
+                      or provide username(s). Comma-separated for OR logic (e.g., "@me,user1,user2").
         created_after (str|int, optional): Time period for task creation (e.g., "7d", "2w", "1m") or days as int.
                       Supports units: h (hours), d (days), w (weeks), m (months), y (years).
         created_before (str|int, optional): Tasks created more than TIME ago (e.g., "7d", "2w", "1m") or days as int.
@@ -2661,29 +2661,42 @@ class Maniphest(Phabfive):
             updated_before_days = parse_time_with_unit(updated_before)
             updated_before = days_to_unix(updated_before_days)
 
-        # Resolve assigned filter - convert @me or username to PHID
-        assigned_phid = None
+        # Resolve assigned filter - convert @me or username(s) to PHID(s)
+        # Supports OR logic with comma-separated values: @me,user1,user2
+        assigned_phids = []
         if assigned:
-            if assigned == "@me":
-                # Get current user's PHID using whoami
-                try:
-                    whoami = self.phab.user.whoami()
-                    assigned_phid = whoami.get("phid")
-                    if assigned_phid:
-                        log.info(f"Filtering by tasks assigned to @me ({whoami.get('userName', 'unknown')})")
-                    else:
-                        log.error("Failed to get current user's PHID")
+            # Split by comma to support OR logic
+            assignees = [a.strip() for a in assigned.split(",")]
+            resolved_names = []
+
+            for assignee in assignees:
+                if assignee == "@me":
+                    # Get current user's PHID using whoami
+                    try:
+                        whoami = self.phab.user.whoami()
+                        phid = whoami.get("phid")
+                        if phid:
+                            assigned_phids.append(phid)
+                            resolved_names.append(f"@me ({whoami.get('userName', 'unknown')})")
+                        else:
+                            log.error("Failed to get current user's PHID")
+                            return
+                    except Exception as e:
+                        log.error(f"Failed to get current user information: {e}")
                         return
-                except Exception as e:
-                    log.error(f"Failed to get current user information: {e}")
-                    return
+                else:
+                    # Resolve username to PHID
+                    phid = self._resolve_user_phid(assignee)
+                    if not phid:
+                        log.error(f"User '{assignee}' not found")
+                        return
+                    assigned_phids.append(phid)
+                    resolved_names.append(assignee)
+
+            if len(assignees) > 1:
+                log.info(f"Filtering by tasks assigned to any of: {', '.join(resolved_names)}")
             else:
-                # Resolve username to PHID
-                assigned_phid = self._resolve_user_phid(assigned)
-                if not assigned_phid:
-                    log.error(f"User '{assigned}' not found")
-                    return
-                log.info(f"Filtering by tasks assigned to {assigned}")
+                log.info(f"Filtering by tasks assigned to {resolved_names[0]}")
 
         project_patterns = None
         project_phids = []
@@ -2765,8 +2778,8 @@ class Maniphest(Phabfive):
                 # We use the 'query' constraint which searches titles and descriptions
                 constraints["query"] = text_query
 
-            if assigned_phid:
-                constraints["assigned"] = [assigned_phid]
+            if assigned_phids:
+                constraints["assigned"] = assigned_phids
 
             if created_after:
                 constraints["createdStart"] = int(created_after)
@@ -2816,8 +2829,8 @@ class Maniphest(Phabfive):
                     if text_query:
                         constraints["query"] = text_query
 
-                    if assigned_phid:
-                        constraints["assigned"] = [assigned_phid]
+                    if assigned_phids:
+                        constraints["assigned"] = assigned_phids
 
                     if created_after:
                         constraints["createdStart"] = int(created_after)
@@ -2868,8 +2881,8 @@ class Maniphest(Phabfive):
                 if text_query:
                     constraints["query"] = text_query
 
-                if assigned_phid:
-                    constraints["assigned"] = [assigned_phid]
+                if assigned_phids:
+                    constraints["assigned"] = assigned_phids
 
                 if created_after:
                     constraints["createdStart"] = int(created_after)


### PR DESCRIPTION
## Summary

Implements support for filtering Maniphest tasks by assignee using the `--assigned` parameter. Users can now filter tasks assigned to themselves using `@me` or specify other users by username. Supports OR logic with comma-separated values for filtering by multiple assignees.

## Features

- **Single assignee filtering**:
  - `--assigned @me` - Filter tasks assigned to current authenticated user
  - `--assigned username` - Filter tasks assigned to specific user

- **Multiple assignees with OR logic**:
  - `--assigned @me,user1,user2` - Filter tasks assigned to ANY of the specified users
  - Comma-separated syntax for OR logic (similar to `--tag` filter)

- **Works with all other filters**:
  - Compatible with `--tag`, `--status`, `--priority`, date filters, etc.
  - Example: `--assigned @me,user1 --tag dynatron --status 'not:in:Resolved'`

## Implementation Details

- Uses Phabricator API's `user.whoami()` to resolve `@me` to current user's PHID
- Resolves usernames to PHIDs using existing `_resolve_user_phid()` method
- Passes PHID list to `maniphest.search` API's `assigned` constraint
- API natively supports OR logic for multiple PHIDs in assigned filter
- Applied to all three query paths in `task_search()` method

## Examples

```bash
# Tasks assigned to me
phabfive maniphest search --assigned @me

# Tasks assigned to me within a specific project
phabfive maniphest search --assigned @me --tag MyProject

# Tasks assigned to me OR user1 that are not resolved
phabfive maniphest search --assigned @me,user1 --tag dynatron --status 'not:in:Resolved'

# Multiple users
phabfive maniphest search --assigned user1,user2,user3
```

## Testing

- Help output verified with updated documentation
- Implementation ready for testing against Phabricator/Phorge instances

## Related

Closes any related issues (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)