### PR TITLE
Hide closed tasks by default in maniphest search

### DIFF
--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -205,6 +205,8 @@ Options:
     --created-before=TIME  Tasks created more than TIME ago (e.g., 1h, 7d, 2w, 1m, 1y)
     --updated-after=TIME   Tasks updated within the last TIME (e.g., 1h, 7d, 2w, 1m, 1y)
     --updated-before=TIME  Tasks updated more than TIME ago (e.g., 1h, 7d, 2w, 1m, 1y)
+    --all                  Include closed tasks (resolved, wontfix, invalid, etc).
+                           By default, search excludes closed tasks.
     --column=PATTERNS      Filter tasks by column transitions (comma=OR, plus=AND).
                            Automatically displays transition history.
                              from:COLUMN[:direction]  - Moved from COLUMN
@@ -687,6 +689,7 @@ def run(cli_args, sub_args):
                     updated_before = get_param(
                         "--updated-before", yaml_params, "updated-before"
                     )
+                    include_closed = get_param("--all", yaml_params, "all", False)
 
                     # Check if any search criteria provided, show usage if not
                     has_criteria = any(
@@ -719,6 +722,7 @@ def run(cli_args, sub_args):
                         status_patterns=status_patterns,
                         show_history=show_history,
                         show_metadata=show_metadata,
+                        include_closed=include_closed,
                     )
 
             if sub_args.get("create"):

--- a/phabfive/maniphest.py
+++ b/phabfive/maniphest.py
@@ -636,6 +636,18 @@ class Maniphest(Phabfive):
                 },
             }
 
+    def _get_open_statuses(self):
+        """
+        Get list of open status keys from the API.
+
+        Returns
+        -------
+        list
+            List of open status key strings (e.g., ["open"])
+        """
+        api_status = self._get_api_status_map()
+        return api_status.get("openStatuses", ["open"])
+
     def _parse_plus_separated(self, values):
         """
         Parse plus-separated values from CLI options.
@@ -2590,6 +2602,7 @@ class Maniphest(Phabfive):
         status_patterns=None,
         show_history=False,
         show_metadata=False,
+        include_closed=False,
     ):
         """
         Search for Phabricator Maniphest tasks with given parameters.
@@ -2622,6 +2635,9 @@ class Maniphest(Phabfive):
                       Must be explicitly requested; not auto-enabled by filters.
         show_metadata (bool, optional): If True, display which boards/priorities/statuses matched the filters.
                       Shows MatchedBoards list, MatchedPriority, and MatchedStatus boolean for debugging filter logic.
+        include_closed (bool, optional): If True, include tasks with closed statuses
+                      (resolved, wontfix, invalid, duplicate, spite). Default is False,
+                      which filters out closed tasks at API level. --status filters are additive.
         """
         # Validation - require at least one filter
         has_any_filter = any(
@@ -2772,6 +2788,13 @@ class Maniphest(Phabfive):
                 log.info("No tag specified, searching across all projects")
             constraints = {}
 
+            # Apply default status filter (exclude closed) unless --all flag is set.
+            # Note: --status filters are additive (applied client-side after API filtering)
+            if not include_closed:
+                open_statuses = self._get_open_statuses()
+                constraints["statuses"] = open_statuses
+                log.info(f"Filtering to open statuses: {open_statuses}")
+
             if text_query:
                 log.info(f"Free-text search: '{text_query}'")
                 # Note: maniphest.search doesn't have a fullText constraint
@@ -2826,6 +2849,11 @@ class Maniphest(Phabfive):
                 for phid in project_phids:
                     constraints = {"projects": [phid]}
 
+                    # Apply default status filter (exclude closed)
+                    if not include_closed:
+                        open_statuses = self._get_open_statuses()
+                        constraints["statuses"] = open_statuses
+
                     if text_query:
                         constraints["query"] = text_query
 
@@ -2877,6 +2905,11 @@ class Maniphest(Phabfive):
             else:
                 # Single project
                 constraints = {"projects": project_phids}
+
+                # Apply default status filter (exclude closed)
+                if not include_closed:
+                    open_statuses = self._get_open_statuses()
+                    constraints["statuses"] = open_statuses
 
                 if text_query:
                     constraints["query"] = text_query


### PR DESCRIPTION
## Summary

- Add `--all` flag to include closed tasks (resolved, wontfix, invalid, duplicate, spite) in search results
- By default, search now excludes closed tasks at the API level to show only actionable items
- `--status` filters are additive - they apply client-side filtering on top of the default exclusion

Fixes #138

## Test plan

- [x] Run `phabfive maniphest search --tag SomeProject` - should only show open tasks
- [x] Run `phabfive maniphest search --tag SomeProject --all` - should show all tasks including closed
- [x] Run `phabfive maniphest search --tag SomeProject --status 'not:in:Resolved'` - should show open tasks with additional status filtering
- [x] Run `uv run tox --skip-missing-interpreters` - all tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)