### PR TITLE
fix: Handle deleted working directory gracefully

### DIFF
--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -2,6 +2,7 @@
 
 # python std lib
 import logging
+import os
 import re
 import sys
 from io import StringIO
@@ -1210,6 +1211,18 @@ def run(cli_args, sub_args):
 
 def cli_entrypoint():
     """Used by setup.py to create a cli entrypoint script."""
+    # Check if current working directory exists
+    # This must be done before importing modules that use os.getcwd()
+    try:
+        os.getcwd()
+    except FileNotFoundError:
+        print(
+            "ERROR: Current working directory no longer exists.\n"
+            "Please change to an existing directory and try again.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     cli_args, sub_args = parse_cli()
 
     try:


### PR DESCRIPTION
## Summary

- Add early check in `cli_entrypoint()` to detect if the current working directory has been deleted
- Provide a clear error message instead of a confusing traceback from the phabricator library

Closes #37

## Test plan

- [x] Run `phabfive` from a directory, then delete that directory from another shell, then run `phabfive` again
- [x] Verify the error message is user-friendly: "ERROR: Current working directory no longer exists."
- [x] Verify normal operation is unaffected when running from an existing directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)