### PR TITLE
refactor: Use importlib.metadata for version

### DIFF
--- a/phabfive/__init__.py
+++ b/phabfive/__init__.py
@@ -5,11 +5,6 @@ import logging
 import logging.config
 import sys
 
-__author__ = "Rickard Eriksson"
-__email__ = "rickard@dynamist.se"
-__version__ = "0.4.0"
-__url__ = "https://github.com/dynamist/phabfive"
-
 
 def init_logging(log_level):
     """

--- a/phabfive/cli.py
+++ b/phabfive/cli.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import sys
+from importlib.metadata import version
 from io import StringIO
 
 # 3rd party imports
@@ -681,17 +682,19 @@ def parse_cli():
     """
     import phabfive
 
+    pkg_version = version("phabfive")
+
     try:
         cli_args = docopt(
             base_args,
             options_first=True,
-            version=phabfive.__version__,
+            version=pkg_version,
             default_help=True,
         )
     except DocoptExit:
         extras(
             True,
-            phabfive.__version__,
+            pkg_version,
             [Option("-h", "--help", 0, True)],
             base_args,
         )
@@ -778,7 +781,7 @@ def parse_cli():
     else:
         extras(
             True,
-            phabfive.__version__,
+            pkg_version,
             [Option("-h", "--help", 0, True)],
             base_args,
         )

--- a/tests/test_phabfive.py
+++ b/tests/test_phabfive.py
@@ -8,10 +8,10 @@ import pytest
 
 
 def test_import_version():
-    try:
-        from phabfive import __version__  # noqa
-    except ImportError:
-        pytest.fail("Unexpected ImportError")
+    from importlib.metadata import version
+
+    pkg_version = version("phabfive")
+    assert pkg_version is not None
 
 
 def test_import_phabfive():


### PR DESCRIPTION
## Summary
- Single-source the version from `pyproject.toml` using `importlib.metadata.version()`
- Remove duplicate `__version__` from `phabfive/__init__.py`
- Remove unused `__author__`, `__email__`, and `__url__` module attributes

## Test plan
- [x] Verify `uv run phabfive --version` shows correct version
- [x] Verify `pytest tests/test_phabfive.py::test_import_version` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)