### PR TITLE
ci: Add single executable releases with Sigstore signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs: build
+    if: ${{ !contains(github.ref_name, '-rc') }}
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -145,7 +146,8 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: [publish-pypi, build-executables]
+    needs: [build, publish-pypi, build-executables]
+    if: ${{ always() && needs.build.result == 'success' && needs.build-executables.result == 'success' && (needs.publish-pypi.result == 'success' || needs.publish-pypi.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Build standalone executables using PyInstaller for 6 platform/arch combinations
- Sign all executables with Sigstore cosign (keyless OIDC signing)
- Attach executables and signatures to GitHub Releases

## Release Artifacts

| Platform | Architecture | Artifact |
|----------|--------------|----------|
| Linux | AMD64 | `phabfive-linux-amd64` |
| Linux | ARM64 | `phabfive-linux-arm64` |
| macOS | AMD64 | `phabfive-macos-amd64` |
| macOS | ARM64 | `phabfive-macos-arm64` |
| Windows | AMD64 | `phabfive-windows-amd64.exe` |
| Windows | ARM64 | `phabfive-windows-arm64.exe` |

Each executable includes a `.sigstore.json` signature bundle.

## Verification

Users can verify signatures with:
```bash
cosign verify-blob phabfive-linux-amd64 \
  --bundle phabfive-linux-amd64.sigstore.json \
  --certificate-identity-regexp="https://github.com/dynamist/phabfive" \
  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
```

## Test plan
- [ ] Push a test tag (e.g., `v0.7.0-rc.1`) to trigger the workflow
- [ ] Verify all 6 executables build successfully
- [ ] Verify signatures are created and attached to release
- [ ] Download and test executables on each platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)