### PR TITLE
Fix project lookup failing when more than 100 projects exist

### DIFF
--- a/phabfive/maniphest/resolvers.py
+++ b/phabfive/maniphest/resolvers.py
@@ -86,18 +86,70 @@ def resolve_project_phids(phab, project: str) -> list[str]:
         log.error("No project name provided. Use '*' to search all projects.")
         return []
 
-    # Fetch all projects from Phabricator regardless of exact match or not to be able to suggest project names
-    log.debug("Fetching all projects from Phabricator")
+    # Check if wildcard search is needed early to optimize API calls
+    has_wildcard = "*" in project
 
-    # Use project.query to get slugs (project.search doesn't return all hashtags)
-    # Note: project.query doesn't support pagination, so we fetch all at once
+    # For exact match without wildcard, try direct lookup first (more efficient)
+    if not has_wildcard:
+        log.debug(f"Attempting direct lookup for project '{project}'")
+        try:
+            # project.search with slugs constraint searches hashtags
+            result = phab.project.search(constraints={"slugs": [project]})
+            if result.get("data"):
+                proj = result["data"][0]
+                phid = proj["phid"]
+                name = proj["fields"]["name"]
+                log.debug(f"Found project '{project}' -> '{name}' (PHID: {phid})")
+                return [phid]
+        except Exception as e:
+            log.debug(f"Direct slug lookup failed: {e}")
+
+        # Also try searching by name in case user provided the display name
+        try:
+            result = phab.project.search(constraints={"query": project})
+            for proj in result.get("data", []):
+                if proj["fields"]["name"].lower() == project.lower():
+                    phid = proj["phid"]
+                    name = proj["fields"]["name"]
+                    log.debug(
+                        f"Found project by name '{project}' -> '{name}' (PHID: {phid})"
+                    )
+                    return [phid]
+        except Exception as e:
+            log.debug(f"Name query lookup failed: {e}")
+
+    # For wildcard searches or when direct lookup fails, fetch all projects with pagination
+    log.debug("Fetching all projects from Phabricator with pagination")
+
+    # Use project.query to get all slugs (project.search doesn't return all hashtags)
+    # project.query supports pagination via limit/offset parameters
     slug_to_phid = {}  # Maps each slug/hashtag to its project PHID
     phid_to_primary_name = {}  # Maps PHID to primary project name
 
     try:
-        # project.query returns a Result object with 'data' key containing projects
-        projects_result = phab.project.query()
-        projects_data = projects_result.get("data", {})
+        # Paginate through all projects
+        page_size = 100
+        offset = 0
+        projects_data = {}
+
+        while True:
+            # project.query returns a Result object with 'data' key containing projects
+            projects_result = phab.project.query(limit=page_size, offset=offset)
+            page_data = projects_result.get("data", {})
+
+            if not page_data:
+                # No more projects
+                break
+
+            # Merge page results into accumulated data
+            projects_data.update(page_data)
+
+            # If we got fewer than page_size, we've reached the end
+            if len(page_data) < page_size:
+                break
+
+            offset += page_size
+            log.debug(f"Fetched {len(projects_data)} projects so far, fetching next page...")
 
         # Process all projects (projects_data is a dict keyed by PHID)
         for phid, project_data in projects_data.items():
@@ -124,9 +176,6 @@ def resolve_project_phids(phab, project: str) -> list[str]:
     # Create case-insensitive lookup mappings for slugs
     lower_slug_to_phid = {slug.lower(): phid for slug, phid in slug_to_phid.items()}
     lower_slug_to_original = {slug.lower(): slug for slug in slug_to_phid.keys()}
-
-    # Check if wildcard search is needed
-    has_wildcard = "*" in project
 
     if has_wildcard:
         if project == "*":
@@ -312,9 +361,26 @@ def resolve_project_phids_for_create(phab, project_names):
         return {"phids": [], "slugs": []}
 
     # Fetch all projects to get both PHIDs and slugs
+    # project.query supports pagination via limit/offset parameters
     try:
-        projects_result = phab.project.query()
-        projects_data = projects_result.get("data", {})
+        page_size = 100
+        offset = 0
+        projects_data = {}
+
+        while True:
+            projects_result = phab.project.query(limit=page_size, offset=offset)
+            page_data = projects_result.get("data", {})
+
+            if not page_data:
+                break
+
+            projects_data.update(page_data)
+
+            if len(page_data) < page_size:
+                break
+
+            offset += page_size
+
     except Exception as e:
         raise PhabfiveRemoteException(f"Failed to fetch projects: {e}")
 

--- a/tests/test_maniphest.py
+++ b/tests/test_maniphest.py
@@ -1644,7 +1644,15 @@ class TestTaskSearchTextQuery:
             "S1": {"phid": "PHID-SPCE-1", "name": "Global", "fullName": "Global", "uri": "/S1"}
         }
 
-        # Mock project resolution
+        # Mock project.search for direct lookup optimization
+        # The result needs to have .get("data") return a list of projects
+        maniphest.phab.project.search.return_value = {
+            "data": [
+                {"phid": "PHID-PROJ-123", "fields": {"name": "MyProject", "slug": "myproject"}}
+            ]
+        }
+
+        # Mock project.query as fallback (shouldn't be called with direct lookup)
         mock_project_result = MagicMock()
         mock_project_result.get.return_value = {
             "PHID-PROJ-123": {
@@ -1689,7 +1697,15 @@ class TestTaskSearchTextQuery:
             "S1": {"phid": "PHID-SPCE-1", "name": "Global", "fullName": "Global", "uri": "/S1"}
         }
 
-        # Mock project resolution
+        # Mock project.search for direct lookup optimization
+        # The result needs to have .get("data") return a list of projects
+        maniphest.phab.project.search.return_value = {
+            "data": [
+                {"phid": "PHID-PROJ-123", "fields": {"name": "MyProject", "slug": "myproject"}}
+            ]
+        }
+
+        # Mock project.query as fallback (shouldn't be called with direct lookup)
         mock_project_result = MagicMock()
         mock_project_result.get.return_value = {
             "PHID-PROJ-123": {
@@ -1836,7 +1852,29 @@ class TestTaskSearchTextQuery:
             "S1": {"phid": "PHID-SPCE-1", "name": "Global", "fullName": "Global", "uri": "/S1"}
         }
 
-        # Mock project resolution
+        # Mock project.search for direct lookup optimization
+        # Returns different results based on the slug being searched
+        def project_search_side_effect(**kwargs):
+            constraints = kwargs.get("constraints", {})
+            slugs = constraints.get("slugs", [])
+            if slugs and "ProjectA" in slugs[0]:
+                return {
+                    "data": [
+                        {"phid": "PHID-PROJ-A", "fields": {"name": "ProjectA", "slug": "projecta"}}
+                    ]
+                }
+            elif slugs and "ProjectB" in slugs[0]:
+                return {
+                    "data": [
+                        {"phid": "PHID-PROJ-B", "fields": {"name": "ProjectB", "slug": "projectb"}}
+                    ]
+                }
+            else:
+                return {"data": []}
+
+        maniphest.phab.project.search.side_effect = project_search_side_effect
+
+        # Mock project.query as fallback
         mock_project_result = MagicMock()
         mock_project_result.get.return_value = {
             "PHID-PROJ-A": {
@@ -1861,5 +1899,5 @@ class TestTaskSearchTextQuery:
 
         # Verify API was called (implementation fetches both projects)
         assert maniphest.phab.maniphest.search.called
-        # Should make multiple calls for OR logic
+        # Should make multiple calls for OR logic (2 projects = 2 calls)
         assert maniphest.phab.maniphest.search.call_count >= 2


### PR DESCRIPTION
## Summary

- Re-applies pagination fix that was lost during the refactor in 0fb3d1b
- Adds direct lookup optimization for exact matches (from 91869a6)
- Preserves all hashtag matching by using `project.query` for wildcards

## Problem

When searching with `--tag '*mål'` on a Phabricator instance with more than 100 projects, only 1 project was returned instead of the expected 10. This was because `project.query()` was called without pagination, returning only the first ~100 projects.

## Solution

1. **Direct lookup optimization**: For exact matches, try `project.search` first (faster)
2. **Pagination**: For wildcards or when direct lookup fails, paginate through all projects using `limit`/`offset`
3. **All hashtags**: Use `project.query` (not `project.search`) for wildcards to preserve matching against all hashtags

## Test plan

- [x] All 98 existing tests pass
- [x] Linting passes
- [x] Manual test on instance with >100 projects

Fixes #110

🤖 Generated with [Claude Code](https://claude.ai/code)