### PR TITLE
docs: Add shell completion section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ phabfive maniphest search "migration tasks" --tag myproject
 phabfive maniphest search --tag myproject --updated-after=1w
 ```
 
+## Shell Completion
+
+Enable tab completion for bash, zsh, or fish:
+
+```bash
+phabfive --install-completion bash
+phabfive --install-completion zsh
+phabfive --install-completion fish
+```
+
+After installation, restart your shell or source your profile.
+
 <details>
 <summary>Manual configuration (advanced)</summary>
 


### PR DESCRIPTION
## Summary

- Adds a Shell Completion section to README.md documenting how to enable tab completion for bash, zsh, or fish

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)