### PR TITLE
feat: Add JSON output format, rename strict to yaml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,17 +65,20 @@ Required: `PHAB_TOKEN` and `PHAB_URL` (via environment or config file)
 
 ## AI Agent Usage
 
-Use `--format=strict` for machine-readable YAML output:
+Use `--format=yaml` or `--format=json` for machine-readable output:
 
 ```bash
 # Get task details as YAML
-phabfive --format=strict T123
+phabfive --format=yaml T123
+
+# Get task details as JSON
+phabfive --format=json T123
 
 # Search tasks with structured output
-phabfive --format=strict maniphest search --tag=projectname
+phabfive --format=json maniphest search --tag=projectname
 
-# Pipe to yq for JSON conversion
-phabfive --format=strict T123 | yq -o json
+# Pipe JSON to jq
+phabfive --format=json T123 | jq '.Task.Title'
 ```
 
 ## Version Management

--- a/phabfive/cli/__init__.py
+++ b/phabfive/cli/__init__.py
@@ -18,7 +18,12 @@ from phabfive.cli.passphrase import passphrase_app  # noqa: E402
 from phabfive.cli.paste import paste_app  # noqa: E402
 from phabfive.cli.repl import repl_app  # noqa: E402
 from phabfive.cli.user import user_app  # noqa: E402
-from phabfive.constants import COMMENTS_SUPPORTED, MONOGRAM_SHORTCUT, MONOGRAMS  # noqa: E402
+from phabfive.constants import (  # noqa: E402
+    COMMENTS_SUPPORTED,
+    MONOGRAM_SHORTCUT,
+    MONOGRAMS,
+    OutputFormat,
+)
 
 # Build pattern dynamically from MONOGRAM_SHORTCUT keys
 _MONOGRAM_PATTERN = re.compile(r"^([" + "".join(MONOGRAM_SHORTCUT.keys()) + r"])(\d+)$")
@@ -41,7 +46,7 @@ def preprocess_monograms(argv: list[str]) -> list[str]:
 
     Examples:
         T123 → maniphest show T123
-        --format=strict T123 → --format=strict maniphest show T123
+        --format=yaml T123 → --format=yaml maniphest show T123
         T123 'comment' → maniphest comment T123 'comment'
         K123 → passphrase K123
         P123 → paste show P123
@@ -80,7 +85,7 @@ def preprocess_monograms(argv: list[str]) -> list[str]:
 
     # Split argv into: before monogram, monogram, after monogram
     before = argv[:monogram_idx]
-    after = argv[monogram_idx + 1:]
+    after = argv[monogram_idx + 1:]  # noqa: E203
 
     # Handle comment shortcut: T123 'text' → maniphest comment T123 'text'
     if prefix in _COMMENT_PREFIXES and after and not after[0].startswith("-"):
@@ -97,6 +102,22 @@ def version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
+def format_callback(value: Optional[str]) -> Optional[OutputFormat]:
+    """Parse format option, handling 'strict' as alias for 'yaml'."""
+    if value is None:
+        return None
+    # Handle legacy 'strict' as alias for 'yaml'
+    if value == "strict":
+        return OutputFormat.yaml
+    try:
+        return OutputFormat(value)
+    except ValueError:
+        valid = ", ".join(f.value for f in OutputFormat)
+        raise typer.BadParameter(
+            f"Invalid format '{value}'. Choose from: {valid}, strict"
+        )
+
+
 @app.callback()
 def main(
     ctx: typer.Context,
@@ -105,10 +126,11 @@ def main(
         "--log-level",
         help="Set log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
     ),
-    output_format: Optional[str] = typer.Option(
+    output_format: Optional[OutputFormat] = typer.Option(
         None,
         "--format",
-        help="Output format: rich, tree, or strict. Auto-detects based on TTY.",
+        callback=format_callback,
+        help="Output format: rich, tree, yaml, or json. Auto-detects based on TTY.",
     ),
     ascii_when: str = typer.Option(
         "auto",
@@ -133,7 +155,8 @@ def main(
     # Store global options in context for subcommands to access
     ctx.ensure_object(dict)
     ctx.obj["log_level"] = log_level
-    ctx.obj["format"] = output_format
+    # Store format as string value for downstream compatibility
+    ctx.obj["format"] = output_format.value if output_format else None
     ctx.obj["ascii"] = ascii_when
     ctx.obj["hyperlink"] = hyperlink_when
 

--- a/phabfive/cli/maniphest.py
+++ b/phabfive/cli/maniphest.py
@@ -57,8 +57,9 @@ def _setup_output_options(ctx: typer.Context):
 def _display_tasks(result, output_format, maniphest_instance):
     """Display task search/show results in the specified format."""
     from phabfive.display import (
+        display_task_json,
         display_task_rich,
-        display_task_strict,
+        display_task_yaml,
         display_task_tree,
     )
 
@@ -71,8 +72,10 @@ def _display_tasks(result, output_format, maniphest_instance):
         for task_dict in result["tasks"]:
             if output_format == "tree":
                 display_task_tree(console, task_dict, maniphest_instance)
-            elif output_format == "strict":
-                display_task_strict(task_dict)
+            elif output_format in ("yaml", "strict"):
+                display_task_yaml(task_dict)
+            elif output_format == "json":
+                display_task_json(task_dict)
             else:  # "rich" (default)
                 display_task_rich(console, task_dict, maniphest_instance)
     except BrokenPipeError:

--- a/phabfive/constants.py
+++ b/phabfive/constants.py
@@ -1,4 +1,16 @@
 # -*- coding: utf-8 -*-
+from enum import Enum
+
+
+class OutputFormat(str, Enum):
+    """Output format options for CLI commands."""
+
+    rich = "rich"  # Human-readable with Rich formatting
+    tree = "tree"  # Tree view with Rich Tree
+    yaml = "yaml"  # Machine-readable YAML
+    json = "json"  # Machine-readable JSON
+
+
 # https://secure.phabricator.com/w/object_name_prefixes/
 MONOGRAMS = {
     "diffusion": "R[0-9]+",
@@ -23,17 +35,25 @@ IO_NEW_URI_CHOICES = ["default", "observe", "mirror", "never"]
 DISPLAY_CHOICES = ["default", "always", "hidden"]
 REPO_STATUS_CHOICES = ["active", "inactive"]
 
-CONFIGURABLES = ["PHABFIVE_DEBUG", "PHAB_TOKEN", "PHAB_URL", "PHAB_SPACE"]
+CONFIGURABLES = [
+    "PHABFIVE_DEBUG",
+    "PHAB_TOKEN",
+    "PHAB_URL",
+    "PHAB_SPACE",
+    "PHAB_FALLBACK",
+]
 DEFAULTS = {
     "PHABFIVE_DEBUG": False,
     "PHAB_TOKEN": "",
     "PHAB_URL": "",
     "PHAB_SPACE": "S1",
+    "PHAB_FALLBACK": "yaml",  # Output format when stdout is not a TTY (yaml or json)
 }
 REQUIRED = ["PHAB_TOKEN", "PHAB_URL"]
 VALIDATORS = {
     "PHAB_URL": r"^http(s)?://([a-zA-Z0-9._-]+|\[[a-fA-F0-9:\.]+\])(:[0-9]+)?/api(/)?$",
     "PHAB_TOKEN": "^[a-zA-Z0-9-]{32}$",
+    "PHAB_FALLBACK": "^(yaml|json)$",
 }
 VALID_EXAMPLES = {"PHAB_URL": "example: http://127.0.0.1/api/"}
 CONFIG_EXAMPLES = {
@@ -57,6 +77,7 @@ __all__ = [
     "COMMENTS_SUPPORTED",
     "MONOGRAM_SHORTCUT",
     "MONOGRAMS",
+    "OutputFormat",
     "REPO_STATUS_CHOICES",
     "REQUIRED",
     "TICKET_PRIORITY_HIGH",

--- a/phabfive/core.py
+++ b/phabfive/core.py
@@ -42,6 +42,7 @@ class Phabfive:
     _ascii_when = "auto"
     _hyperlink_when = "auto"
     _output_format = "rich"
+    _fallback_format = "yaml"  # Format used when stdout is not a TTY
     # Maximum line width for rich format (to prevent YAML breaking)
     MAX_LINE_WIDTH = 4096
 
@@ -128,18 +129,18 @@ class Phabfive:
 
         return False
 
-    @staticmethod
-    def _get_auto_format():
+    @classmethod
+    def _get_auto_format(cls):
         """Determine default output format based on whether stdout is a TTY.
 
         Returns:
-            str: "rich" if stdout is a terminal, "strict" if piped/redirected
+            str: "rich" if stdout is a terminal, PHAB_FALLBACK if piped/redirected
         """
         import sys
 
-        # If output is piped or redirected, use strict format for machine processing
+        # If output is piped or redirected, use fallback format for machine processing
         if not sys.stdout.isatty():
-            return "strict"
+            return cls._fallback_format
 
         # If output is to a terminal, use rich format for human readability
         return "rich"
@@ -225,7 +226,7 @@ class Phabfive:
             if len(line) > self.MAX_LINE_WIDTH:
                 raise PhabfiveDataException(
                     f"{field_name} line {i + 1} exceeds maximum width of {self.MAX_LINE_WIDTH} characters "
-                    f"(length: {len(line)}). Use --format=strict for guaranteed valid YAML output."
+                    f"(length: {len(line)}). Use --format=yaml for guaranteed valid YAML output."
                 )
 
     def __init__(self):
@@ -259,6 +260,9 @@ class Phabfive:
                     error += ", " + example
 
                 raise PhabfiveConfigException(error)
+
+        # Set fallback format from config (used when stdout is not a TTY)
+        Phabfive._fallback_format = self.conf.get("PHAB_FALLBACK", "yaml")
 
         self.phab = Phabricator(
             host=self._normalize_url(self.conf.get("PHAB_URL")),

--- a/phabfive/display.py
+++ b/phabfive/display.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Display functions for Maniphest tasks."""
 
+import json
 import sys
 from io import StringIO
 
@@ -303,7 +304,7 @@ def display_task_tree(console, task_dict, phabfive_instance):
     console.print(tree)
 
 
-def display_task_strict(task_dict):
+def display_task_yaml(task_dict):
     """Display task as strict YAML via ruamel.yaml.
 
     Guaranteed conformant YAML output for piping to yq/jq.
@@ -378,6 +379,82 @@ def display_task_strict(task_dict):
     print(stream.getvalue(), end="")
 
 
+def display_task_json(task_dict):
+    """Display task as JSON.
+
+    Machine-readable JSON output for piping to jq or other tools.
+    No hyperlinks, no Rich formatting.
+
+    Parameters
+    ----------
+    task_dict : dict
+        Task data dictionary with Link, Task, Boards, History, Metadata, etc.
+    """
+    # Build clean dict - use _url for the Link (plain URL string)
+    output = {"Link": task_dict.get("_url", "")}
+
+    # Add Task section
+    if task_dict.get("Task"):
+        output["Task"] = {}
+        for k, v in task_dict["Task"].items():
+            # Convert PreservedScalarString to plain string
+            if isinstance(v, PreservedScalarString):
+                output["Task"][k] = str(v)
+            else:
+                output["Task"][k] = v
+
+    # Add Assignee if present (extract plain text from Rich Text if needed)
+    assignee = task_dict.get("_assignee")
+    if assignee is not None:
+        # Convert Rich Text to plain string, or use string directly
+        if isinstance(assignee, Text):
+            output["Assignee"] = assignee.plain
+        else:
+            output["Assignee"] = str(assignee)
+
+    # Add Space if present (extract plain text from Rich Text if needed)
+    space = task_dict.get("_space")
+    if space is not None:
+        # Convert Rich Text to plain string, or use string directly
+        if isinstance(space, Text):
+            output["Space"] = space.plain
+        else:
+            output["Space"] = str(space)
+
+    # Add Boards section without internal keys
+    if task_dict.get("Boards"):
+        boards = {}
+        for board_name, board_data in task_dict["Boards"].items():
+            if isinstance(board_data, dict):
+                boards[board_name] = {
+                    k: v for k, v in board_data.items() if not k.startswith("_")
+                }
+            else:
+                boards[board_name] = board_data
+        output["Boards"] = boards
+
+    # Add History section if present
+    if task_dict.get("History"):
+        output["History"] = task_dict["History"]
+
+    # Add Comments section if present
+    if task_dict.get("Comments"):
+        # Convert PreservedScalarString to plain strings
+        comments = []
+        for comment in task_dict["Comments"]:
+            if isinstance(comment, PreservedScalarString):
+                comments.append(str(comment))
+            else:
+                comments.append(comment)
+        output["Comments"] = comments
+
+    # Add Metadata section if present
+    if task_dict.get("Metadata"):
+        output["Metadata"] = task_dict["Metadata"]
+
+    print(json.dumps(output, indent=2))
+
+
 def display_tasks(result, output_format, phabfive_instance):
     """Display task search/show results in the specified format.
 
@@ -386,7 +463,7 @@ def display_tasks(result, output_format, phabfive_instance):
     result : dict
         Result from task_search() or task_show() containing 'tasks' list
     output_format : str
-        One of 'rich', 'tree', or 'strict'
+        One of 'rich', 'tree', 'yaml', or 'json'
     phabfive_instance : Phabfive
         Instance to access formatting helpers
     """
@@ -399,8 +476,10 @@ def display_tasks(result, output_format, phabfive_instance):
         for task_dict in result["tasks"]:
             if output_format == "tree":
                 display_task_tree(console, task_dict, phabfive_instance)
-            elif output_format == "strict":
-                display_task_strict(task_dict)
+            elif output_format in ("yaml", "strict"):
+                display_task_yaml(task_dict)
+            elif output_format == "json":
+                display_task_json(task_dict)
             else:  # "rich" (default)
                 display_task_rich(console, task_dict, phabfive_instance)
     except BrokenPipeError:

--- a/tests/test_phabfive.py
+++ b/tests/test_phabfive.py
@@ -33,9 +33,9 @@ class TestAutoFormatDetection:
             assert result == "rich"
 
     def test_get_auto_format_piped(self):
-        """Test auto-format returns 'strict' when stdout is piped/redirected."""
+        """Test auto-format returns 'yaml' when stdout is piped/redirected."""
         from phabfive.core import Phabfive
 
         with mock.patch("sys.stdout.isatty", return_value=False):
             result = Phabfive._get_auto_format()
-            assert result == "strict"
+            assert result == "yaml"


### PR DESCRIPTION
## Summary

- Add `--format=json` for JSON output
- Rename `--format=strict` to `--format=yaml` (clearer naming)
- Keep `strict` as hidden alias for backwards compatibility
- Add `OutputFormat` enum for shell completion of format values
- Add `PHAB_FALLBACK` config option (yaml/json) for non-TTY output

## Usage

```bash
# JSON output
phabfive --format=json T123

# YAML output (formerly --format=strict)
phabfive --format=yaml T123

# Configure default fallback for piped output
export PHAB_FALLBACK=json
phabfive T123 | jq '.Task.Title'
```

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)