### PR TITLE
fix: Add show subcommand to passphrase for monogram shortcut

### DIFF
--- a/phabfive/cli/__init__.py
+++ b/phabfive/cli/__init__.py
@@ -68,7 +68,7 @@ def preprocess_monograms(argv: list[str]) -> list[str]:
         T123 → maniphest show T123
         --format=yaml T123 → --format=yaml maniphest show T123
         T123 'comment' → maniphest comment T123 'comment'
-        K123 → passphrase K123
+        K123 → passphrase show K123
         P123 → paste show P123
         R123 → diffusion branch list R123
     """
@@ -77,6 +77,7 @@ def preprocess_monograms(argv: list[str]) -> list[str]:
 
     # Find the first non-option argument that matches a monogram
     monogram_idx = None
+    non_option_args = []  # Track non-option args before monogram
     skip_next = False
     for i, arg in enumerate(argv[1:], start=1):
         if skip_next:
@@ -94,6 +95,7 @@ def preprocess_monograms(argv: list[str]) -> list[str]:
         if match:
             monogram_idx = i
             break
+        non_option_args.append(arg)
 
     if monogram_idx is None:
         return argv
@@ -102,6 +104,10 @@ def preprocess_monograms(argv: list[str]) -> list[str]:
     match = _MONOGRAM_PATTERN.match(monogram)
     prefix = match.group(1)
     expansion = MONOGRAM_SHORTCUT[prefix]
+
+    # Check if already expanded (non-option args before monogram match expansion)
+    if non_option_args == expansion:
+        return argv
 
     # Split argv into: before monogram, monogram, after monogram
     before = argv[:monogram_idx]

--- a/phabfive/cli/passphrase.py
+++ b/phabfive/cli/passphrase.py
@@ -5,26 +5,30 @@ import typer
 
 from phabfive.exceptions import PhabfiveConfigException
 
-passphrase_app = typer.Typer(
-    help="The passphrase app",
-    invoke_without_command=True,
-)
+passphrase_app = typer.Typer(help="The passphrase app")
 
 
-@passphrase_app.callback(invoke_without_command=True)
-def passphrase_callback(
-    ctx: typer.Context,
-    id: str = typer.Argument(..., help="Passphrase ID (e.g., K123)"),
-) -> None:
-    """Retrieve a secret from Passphrase by ID."""
+def _get_passphrase_app():
+    """Get Passphrase app instance with config error handling."""
     from phabfive.passphrase import Passphrase
 
     try:
-        passphrase = Passphrase()
-        secret = passphrase.get_secret(id)
-        typer.echo(secret)
+        return Passphrase()
     except PhabfiveConfigException as e:
         from phabfive.setup import offer_setup_on_error
 
         if not offer_setup_on_error(str(e)):
             raise typer.Exit(1)
+        # If setup succeeded, try again
+        return Passphrase()
+
+
+@passphrase_app.command()
+def show(
+    ctx: typer.Context,
+    id: str = typer.Argument(..., help="Passphrase ID (e.g., K123)"),
+) -> None:
+    """Retrieve a secret from Passphrase by ID."""
+    passphrase = _get_passphrase_app()
+    secret = passphrase.get_secret(id)
+    typer.echo(secret)

--- a/phabfive/constants.py
+++ b/phabfive/constants.py
@@ -40,7 +40,7 @@ MONOGRAMS = {
 # Monogram shortcuts for CLI: maps prefix letter to command expansion
 MONOGRAM_SHORTCUT = {
     "T": ["maniphest", "show"],  # T123 → maniphest show T123
-    "K": ["passphrase"],  # K123 → passphrase K123
+    "K": ["passphrase", "show"],  # K123 → passphrase show K123
     "P": ["paste", "show"],  # P123 → paste show P123
     "R": ["diffusion", "branch", "list"],  # R123 → diffusion branch list R123
 }


### PR DESCRIPTION
## Summary
- Add explicit `show` subcommand to passphrase CLI (consistent with paste)
- Update monogram shortcut from `["passphrase"]` to `["passphrase", "show"]`
- Fix `preprocess_monograms` to skip expansion when command is already formed

Fixes the issue where `phabfive passphrase K6` (or `phabfive K6`) failed with "No such command 'K6'". The previous implementation used `invoke_without_command=True` with a callback argument, which caused Typer to interpret K6 as a command name rather than the ID argument.

## Test plan
- [x] `phabfive K6` works (expands to `passphrase show K6`)
- [x] `phabfive passphrase show K6` works (no double expansion)
- [x] `phabfive --format=yaml K6` works
- [x] All tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)