### PR TITLE
feat: Add structured output for passphrase show command

### DIFF
--- a/phabfive/cli/passphrase.py
+++ b/phabfive/cli/passphrase.py
@@ -29,10 +29,16 @@ def show(
     id: str = typer.Argument(..., help="Passphrase ID (e.g., K123)"),
 ) -> None:
     """Retrieve a secret from Passphrase by ID."""
+    from phabfive.core import Phabfive
+    from phabfive.passphrase_display import display_passphrase
+
     passphrase = _get_passphrase_app()
     try:
-        secret = passphrase.get_secret(id)
-        typer.echo(secret)
+        data = passphrase.get_passphrase(id)
+
+        format_arg = ctx.obj.get("format") if ctx.obj else None
+        output_format = format_arg if format_arg else Phabfive._get_auto_format()
+        display_passphrase(data, output_format, passphrase)
     except PhabfiveDataException as e:
         typer.echo(f"ERROR: {e}", err=True)
         raise typer.Exit(1)

--- a/phabfive/constants.py
+++ b/phabfive/constants.py
@@ -9,6 +9,7 @@ class OutputFormat(str, Enum):
     tree = "tree"  # Tree view with Rich Tree
     yaml = "yaml"  # Machine-readable YAML
     json = "json"  # Machine-readable JSON
+    simple = "simple"  # Minimal output (e.g., just the secret for passphrase)
 
 
 class AutoOption(str, Enum):

--- a/phabfive/passphrase.py
+++ b/phabfive/passphrase.py
@@ -24,17 +24,43 @@ class Passphrase(Phabfive):
     def _validate_identifier(self, id_):
         return re.match(f"^{MONOGRAMS['passphrase']}$", id_)
 
-    def get_secret(self, ids):
-        if not self._validate_identifier(ids):
+    def get_passphrase(self, id_str):
+        """Retrieve passphrase data by ID.
+
+        Parameters
+        ----------
+        id_str : str
+            Passphrase ID (e.g., "K123")
+
+        Returns
+        -------
+        dict
+            Structured passphrase data with keys:
+            - id: str (e.g., "K1")
+            - url: str (full URL to passphrase)
+            - _link: Rich Text (OSC8 hyperlink for rich/tree formats)
+            - type: str (Password, Token, SSH Key, Note)
+            - name: str (credential name)
+            - username: str or None (only for Password type)
+            - secret: str (the actual secret value)
+
+        Raises
+        ------
+        PhabfiveDataException
+            If ID is invalid, no data found, or access denied
+        PhabfiveRemoteException
+            If API call fails
+        """
+        if not self._validate_identifier(id_str):
             raise PhabfiveDataException(
-                f"Invalid passphrase ID '{ids}'. Expected format: K123"
+                f"Invalid passphrase ID '{id_str}'. Expected format: K123"
             )
 
-        ids = ids.replace("K", "")
+        numeric_id = id_str.replace("K", "")
 
         try:
             response = self.phab.passphrase.query(
-                ids=[ids],
+                ids=[numeric_id],
                 needSecrets=1,
             )
         except APIError as e:
@@ -43,27 +69,69 @@ class Passphrase(Phabfive):
         has_data = response.get("data", {})
 
         if not has_data:
-            raise PhabfiveDataException(f"K{ids} has no data or other error")
+            raise PhabfiveDataException(f"K{numeric_id} has no data or other error")
 
-        # TODO: I am doing the logging wrong, in this module the loglevel
-        # is INFO, even if env PHABFIVE_DEBUG=1
         log.debug(json.dumps(response["data"], indent=2))
 
-        # When Conduit Access is not accepted for Passphrase the "response" will return value "noAPIAccess" in key "material" instead of the secret
-        api_access_value = response["data"].get(next(iter(response["data"])))[
-            "material"
-        ]
-        no_api_access = "noAPIAccess" in api_access_value
+        # Get the first (and only) entry
+        data = next(iter(response["data"].values()))
 
-        if no_api_access:
+        # Check for API access denial
+        material = data.get("material", {})
+
+        # Handle material being a list (empty) or dict
+        if isinstance(material, list):
+            material = {}
+
+        if "noAPIAccess" in material:
             raise PhabfiveDataException(
-                f"Access denied, visit {self.url}/K{ids} to allow Conduit",
+                f"Access denied, visit {self.url}/K{numeric_id} to allow Conduit",
             )
 
-        # Extract and return the secret value
-        for value in response["data"].values():
-            for secret_type, secret_value in value["material"].items():
-                if secret_type == "password":  # nosec-B105
-                    return secret_value
+        # Map API type to display type
+        type_map = {
+            "password": "Password",
+            "token": "Token",
+            "ssh-generated-key": "SSH Key",
+            "ssh-key-text": "SSH Key",
+            "note": "Note",
+        }
 
-        raise PhabfiveDataException(f"No password found in K{ids}")
+        # Extract secret from material (different key per type)
+        secret = (
+            material.get("password")  # nosec-B105
+            or material.get("token")
+            or material.get("privateKey")
+            or material.get("note")
+            or ""
+        )
+
+        monogram = f"K{data['id']}"
+        url = f"{self.url}/{monogram}"
+        credential_type = data.get("type", "")
+
+        return {
+            "id": monogram,
+            "url": url,
+            "_link": self.format_link(url, monogram),
+            "type": type_map.get(credential_type, credential_type or "Unknown"),
+            "name": data.get("name", ""),
+            "username": data.get("username"),
+            "secret": secret,
+        }
+
+    def get_secret(self, ids):
+        """Retrieve only the secret value.
+
+        Parameters
+        ----------
+        ids : str
+            Passphrase ID (e.g., "K123")
+
+        Returns
+        -------
+        str
+            The secret value
+        """
+        data = self.get_passphrase(ids)
+        return data["secret"]

--- a/phabfive/passphrase_display.py
+++ b/phabfive/passphrase_display.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+"""Display functions for Passphrase credentials."""
+
+import json
+import sys
+from io import StringIO
+
+from rich.text import Text
+from rich.tree import Tree
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import PreservedScalarString
+
+
+def display_passphrase_rich(console, passphrase_dict, phabfive_instance):
+    """Display a passphrase in YAML-like format using Rich.
+
+    Parameters
+    ----------
+    console : Console
+        Rich Console instance for output
+    passphrase_dict : dict
+        Passphrase data dictionary with _link, url, type, name, username, secret
+    phabfive_instance : Phabfive
+        Instance to access format_link() and url
+    """
+    link = passphrase_dict.get("_link")
+    passphrase_type = passphrase_dict.get("type", "Unknown")
+    name = passphrase_dict.get("name", "")
+    username = passphrase_dict.get("username")
+    secret = passphrase_dict.get("secret", "")
+
+    # Print link
+    console.print(Text.assemble("- Link: ", link))
+
+    # Print Type
+    console.print(f"  Type: {passphrase_type}")
+
+    # Print Name
+    console.print(f"  Name: {name}")
+
+    # Print Username (only when present)
+    if username:
+        console.print(f"  Username: {username}")
+
+    # Print Secret (handle multi-line for SSH keys)
+    if "\n" in secret:
+        console.print("  Secret: |-")
+        for line in secret.splitlines():
+            console.print(f"    {line}")
+    else:
+        console.print(f"  Secret: {secret}")
+
+
+def display_passphrase_tree(console, passphrase_dict, phabfive_instance):
+    """Display a passphrase in tree format using Rich Tree.
+
+    Parameters
+    ----------
+    console : Console
+        Rich Console instance for output
+    passphrase_dict : dict
+        Passphrase data dictionary with _link, url, type, name, username, secret
+    phabfive_instance : Phabfive
+        Instance to access format_link() and url
+    """
+    link = passphrase_dict.get("_link")
+    passphrase_type = passphrase_dict.get("type", "Unknown")
+    name = passphrase_dict.get("name", "")
+    username = passphrase_dict.get("username")
+    secret = passphrase_dict.get("secret", "")
+
+    # Create tree with link as root
+    tree = Tree(link)
+
+    # Add fields
+    tree.add(f"Type: {passphrase_type}")
+    tree.add(f"Name: {name}")
+
+    if username:
+        tree.add(f"Username: {username}")
+
+    # For multi-line secrets, show first line only
+    if "\n" in secret:
+        first_line = secret.split("\n")[0]
+        if len(first_line) > 50:
+            first_line = first_line[:47] + "..."
+        tree.add(f"Secret: {first_line}")
+    else:
+        tree.add(f"Secret: {secret}")
+
+    console.print(tree)
+
+
+def display_passphrase_yaml(passphrase_dict):
+    """Display passphrase as strict YAML via ruamel.yaml.
+
+    Guaranteed conformant YAML output for piping to yq/jq.
+    No hyperlinks, no Rich formatting.
+
+    Parameters
+    ----------
+    passphrase_dict : dict
+        Passphrase data dictionary with url, type, name, username, secret
+    """
+    yaml = YAML()
+    yaml.default_flow_style = False
+
+    # Build clean dict - use url for the Link (plain URL string)
+    output = {
+        "Link": passphrase_dict.get("url", ""),
+        "Type": passphrase_dict.get("type", "Unknown"),
+        "Name": passphrase_dict.get("name", ""),
+    }
+
+    # Include Username only if present
+    username = passphrase_dict.get("username")
+    if username:
+        output["Username"] = username
+
+    # Handle multi-line secrets with block scalar
+    secret = passphrase_dict.get("secret", "")
+    if "\n" in secret:
+        output["Secret"] = PreservedScalarString(secret)
+    else:
+        output["Secret"] = secret
+
+    stream = StringIO()
+    yaml.dump([output], stream)
+    print(stream.getvalue(), end="")
+
+
+def display_passphrase_json(passphrase_dict):
+    """Display passphrase as JSON.
+
+    Machine-readable JSON output for piping to jq or other tools.
+    No hyperlinks, no Rich formatting.
+
+    Parameters
+    ----------
+    passphrase_dict : dict
+        Passphrase data dictionary with url, type, name, username, secret
+    """
+    output = {
+        "Link": passphrase_dict.get("url", ""),
+        "Type": passphrase_dict.get("type", "Unknown"),
+        "Name": passphrase_dict.get("name", ""),
+    }
+
+    # Include Username only if present
+    username = passphrase_dict.get("username")
+    if username:
+        output["Username"] = username
+
+    output["Secret"] = passphrase_dict.get("secret", "")
+
+    print(json.dumps(output, indent=2))
+
+
+def display_passphrase_simple(passphrase_dict):
+    """Display only the secret value (for piping).
+
+    Parameters
+    ----------
+    passphrase_dict : dict
+        Passphrase data dictionary with secret
+    """
+    print(passphrase_dict.get("secret", ""))
+
+
+def display_passphrase(passphrase_dict, output_format, phabfive_instance):
+    """Display passphrase in the specified format.
+
+    Parameters
+    ----------
+    passphrase_dict : dict
+        Passphrase data from get_passphrase()
+    output_format : str
+        One of 'rich', 'tree', 'yaml', 'json', or 'simple'
+    phabfive_instance : Phabfive
+        Instance to access formatting helpers
+    """
+    console = phabfive_instance.get_console()
+
+    try:
+        if output_format == "simple":
+            display_passphrase_simple(passphrase_dict)
+        elif output_format == "tree":
+            display_passphrase_tree(console, passphrase_dict, phabfive_instance)
+        elif output_format in ("yaml", "strict"):
+            display_passphrase_yaml(passphrase_dict)
+        elif output_format == "json":
+            display_passphrase_json(passphrase_dict)
+        else:  # "rich" (default)
+            display_passphrase_rich(console, passphrase_dict, phabfive_instance)
+    except BrokenPipeError:
+        # Handle pipe closed by consumer (e.g., head, less)
+        sys.stderr.close()
+        sys.exit(0)


### PR DESCRIPTION
## Summary

- Add `get_passphrase()` returning structured dict with type, name, username, secret
- Support all passphrase types: Password, Token, SSH Key, Note
- Add display functions for rich/tree/yaml/json/simple formats
- Add `--format=simple` for secret-only output (for piping)
- Clickable OSC8 links for monograms in rich/tree formats
- Handle empty material arrays for deprecated credentials

## Usage

```bash
phabfive passphrase show K6                    # rich format (default)
phabfive --format yaml passphrase show K6      # YAML format
phabfive --format json passphrase show K6      # JSON format
phabfive --format simple passphrase show K6    # secret only (for piping)
```

## Example Output

```
- Link: K6
  Type: Password
  Name: Universal Dynamist Passphrase
  Username: dynamist
  Secret: ****
```

## Test plan

- [x] Test Password type (K6)
- [x] Test Note type with empty material (K28)
- [x] Test all output formats: rich, yaml, json, simple
- [x] Run tests: `uv run pytest tests/ -x -q` (309 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)