### PR TITLE
Unify create command UX with edit command

### DIFF
--- a/phabfive/cli/maniphest.py
+++ b/phabfive/cli/maniphest.py
@@ -208,7 +208,16 @@ def create(
         help="Skip confirmation prompt (required for non-interactive use)",
     ),
 ) -> None:
-    """Create a new Maniphest task."""
+    """Create a new Maniphest task.
+
+    \b
+    Examples:
+        phabfive maniphest create "Fix bug"
+        phabfive maniphest create "New feature" --assign=@me
+        phabfive maniphest create "Task" --priority=high --tag=Sprint
+        phabfive maniphest create "Task" --tag=Board --column=Backlog
+        echo "Description" | phabfive maniphest create "Task" --description=-
+    """
     maniphest = _get_maniphest_app()
 
     if with_template:

--- a/phabfive/cli/maniphest.py
+++ b/phabfive/cli/maniphest.py
@@ -273,23 +273,29 @@ def create(
         )
         if result:
             if result.get("dry_run"):
-                typer.echo("\n--- DRY RUN ---")
-                typer.echo(f"Title: {result['title']}")
+                print("[DRY RUN] Would create task:")
+                print(f"  Title: {result['title']}")
                 if result.get("description"):
-                    typer.echo(f"Description: {result['description']}")
+                    desc = result["description"]
+                    lines = desc.split("\n")
+                    if len(lines) == 1 and len(desc) <= 60:
+                        print(f"  Description: {desc}")
+                    else:
+                        print("  Description:")
+                        for line in lines:
+                            print(f"    {line}")
                 if result.get("priority"):
-                    typer.echo(f"Priority: {result['priority']}")
+                    print(f"  Priority: {result['priority']}")
                 if result.get("status"):
-                    typer.echo(f"Status: {result['status']}")
+                    print(f"  Status: {result['status']}")
                 if result.get("assignee"):
-                    typer.echo(f"Assignee: {result['assignee']}")
+                    print(f"  Assignee: {result['assignee']}")
                 if result.get("tags"):
-                    typer.echo(f"Tags: {', '.join(result['tags'])}")
+                    print(f"  Tags: {', '.join(result['tags'])}")
                 if result.get("column"):
-                    typer.echo(f"Column: {result['column']}")
+                    print(f"  Column: {result['column']}")
                 if result.get("subscribers"):
-                    typer.echo(f"Subscribers: {', '.join(result['subscribers'])}")
-                typer.echo("--- END DRY RUN ---\n")
+                    print(f"  Subscribers: {', '.join(result['subscribers'])}")
             else:
                 typer.echo(result["uri"])
                 if result.get("tag_slugs"):

--- a/phabfive/cli/maniphest.py
+++ b/phabfive/cli/maniphest.py
@@ -232,7 +232,7 @@ def create(
             # Open $EDITOR for description (only in interactive mode)
             from phabfive.editor import edit_text
 
-            final_description = edit_text("")
+            final_description = edit_text("", prefix="description-")
             if final_description and not force:
                 print()
                 print(final_description)
@@ -243,7 +243,9 @@ def create(
 
         # Validate --column requires --tag
         if column and not tag:
-            sys.stderr.write("Error: --column requires --tag to specify board context\n")
+            sys.stderr.write(
+                "Error: --column requires --tag to specify board context\n"
+            )
             raise typer.Exit(1)
 
         # Resolve board PHID if column is specified

--- a/phabfive/cli/maniphest.py
+++ b/phabfive/cli/maniphest.py
@@ -161,26 +161,51 @@ def create(
         None, "--with", help="Load task creation template from YAML file"
     ),
     description: Optional[str] = typer.Option(
-        None, "--description", help="Task description"
+        None,
+        "--description",
+        help="Task description (use - to read from stdin, or omit to open $EDITOR)",
     ),
     tag: Optional[List[str]] = typer.Option(
         None,
         "--tag",
-        help="Project/workboard tag (repeatable)",
+        help="Add to project/workboard (repeatable)",
         autocompletion=complete_tag,
     ),
-    assign: Optional[str] = typer.Option(None, "--assign", help="Assignee username"),
+    column: Optional[str] = typer.Option(
+        None,
+        "--column",
+        help="Initial column on board (requires --tag)",
+        autocompletion=complete_column,
+    ),
+    assign: Optional[str] = typer.Option(
+        None,
+        "--assign",
+        help="Set assignee (username or @me for yourself)",
+    ),
     status: Optional[str] = typer.Option(
-        None, "--status", help="Task status", autocompletion=complete_status
+        None,
+        "--status",
+        help="Set status (open, resolved, wontfix, invalid, duplicate, etc.)",
+        autocompletion=complete_status,
     ),
     priority: Optional[str] = typer.Option(
-        None, "--priority", help="Task priority", autocompletion=complete_priority
+        None,
+        "--priority",
+        help="Set priority (unbreak, high, normal, low, wish)",
+        autocompletion=complete_priority,
     ),
     subscribe: Optional[List[str]] = typer.Option(
-        None, "--subscribe", help="Subscriber username (repeatable)"
+        None,
+        "--subscribe",
+        help="Add subscriber (username or @me, repeatable)",
     ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Preview without creating task"
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Skip confirmation prompt (required for non-interactive use)",
     ),
 ) -> None:
     """Create a new Maniphest task."""
@@ -194,15 +219,54 @@ def create(
                 indent = "  " * task["depth"]
                 typer.echo(f"{indent}- {task['title']}")
     elif title:
-        # CLI mode
+        # CLI mode - handle description input modes
+        final_description = description
+
+        if description == "-":
+            # Read from stdin
+            if sys.stdin.isatty():
+                sys.stderr.write("Error: --description - requires input from stdin\n")
+                raise typer.Exit(1)
+            final_description = sys.stdin.read().rstrip()
+        elif description is None and sys.stdin.isatty() and not dry_run:
+            # Open $EDITOR for description (only in interactive mode)
+            from phabfive.editor import edit_text
+
+            final_description = edit_text("")
+            if final_description and not force:
+                print()
+                print(final_description)
+                print()
+                if not typer.confirm("Create task with this description?"):
+                    print("Cancelled")
+                    raise typer.Exit(0)
+
+        # Validate --column requires --tag
+        if column and not tag:
+            sys.stderr.write("Error: --column requires --tag to specify board context\n")
+            raise typer.Exit(1)
+
+        # Resolve board PHID if column is specified
+        board_phid = None
+        if column and tag:
+            # Use the first tag as the board context
+            board_phids = maniphest._resolve_project_phids(tag[0])
+            if board_phids:
+                board_phid = board_phids[0]
+            else:
+                sys.stderr.write(f"Error: Board not found: {tag[0]}\n")
+                raise typer.Exit(1)
+
         result = maniphest.create_task(
             title=title,
-            description=description,
+            description=final_description,
             tags=tag,
             assignee=assign,
             status=status,
             priority=priority,
             subscribers=subscribe,
+            column=column,
+            board_phid=board_phid,
             dry_run=dry_run,
         )
         if result:
@@ -219,6 +283,8 @@ def create(
                     typer.echo(f"Assignee: {result['assignee']}")
                 if result.get("tags"):
                     typer.echo(f"Tags: {', '.join(result['tags'])}")
+                if result.get("column"):
+                    typer.echo(f"Column: {result['column']}")
                 if result.get("subscribers"):
                     typer.echo(f"Subscribers: {', '.join(result['subscribers'])}")
                 typer.echo("--- END DRY RUN ---\n")

--- a/phabfive/edit/core.py
+++ b/phabfive/edit/core.py
@@ -260,7 +260,7 @@ class Edit(Phabfive):
                 # Open editor with current description
                 from phabfive.editor import edit_text
 
-                new_desc = edit_text(current_desc)
+                new_desc = edit_text(current_desc, prefix="description-")
                 if new_desc is None:
                     print("Description edit cancelled")
                     return 0

--- a/phabfive/editor.py
+++ b/phabfive/editor.py
@@ -13,11 +13,12 @@ def get_editor():
     return os.environ.get("EDITOR") or os.environ.get("VISUAL") or "vi"
 
 
-def edit_text(initial_text="", suffix=".remarkup"):
+def edit_text(initial_text="", prefix="", suffix=".remarkup"):
     """Open external editor and return edited text.
 
     Args:
         initial_text: Text to pre-populate the editor with
+        prefix: File prefix (hints at what field is being edited)
         suffix: File suffix (helps editors with syntax highlighting)
 
     Returns:
@@ -27,7 +28,7 @@ def edit_text(initial_text="", suffix=".remarkup"):
             - Editor returns non-zero exit code
     """
     with tempfile.NamedTemporaryFile(
-        mode="w", suffix=suffix, delete=False, encoding="utf-8"
+        mode="w", prefix=prefix, suffix=suffix, delete=False, encoding="utf-8"
     ) as f:
         f.write(initial_text)
         temp_path = f.name

--- a/phabfive/maniphest/core.py
+++ b/phabfive/maniphest/core.py
@@ -1634,9 +1634,7 @@ class Maniphest(Phabfive):
                 assignee_phid = whoami.get("phid")
                 assignee_display = whoami.get("userName", "@me")
                 if not assignee_phid:
-                    raise PhabfiveConfigException(
-                        "Failed to get current user's PHID"
-                    )
+                    raise PhabfiveConfigException("Failed to get current user's PHID")
             else:
                 assignee_phid = self._resolve_user_phid(assignee)
                 if not assignee_phid:

--- a/phabfive/maniphest/core.py
+++ b/phabfive/maniphest/core.py
@@ -2032,8 +2032,14 @@ class Maniphest(Phabfive):
 
         if dry_run:
             print(f"[DRY RUN] Would apply to T{task_id}:")
-            for txn in transactions:
-                print(f"  - {txn['type']}: {txn['value']}")
+            for change in changes:
+                field = change["field"]
+                old = change["old"]
+                new = change["new"]
+                if old is None:
+                    print(f"  {field}: {new}")
+                else:
+                    print(f"  {field}: {old} → {new}")
             return {"task_id": task_id, "changes": changes, "dry_run": True}
 
         # Apply transactions

--- a/phabfive/maniphest/core.py
+++ b/phabfive/maniphest/core.py
@@ -1558,6 +1558,8 @@ class Maniphest(Phabfive):
         status=None,
         priority=None,
         subscribers=None,
+        column=None,
+        board_phid=None,
         dry_run=False,
     ):
         """
@@ -1572,13 +1574,17 @@ class Maniphest(Phabfive):
         tags : list, optional
             List of project names/tags (may contain plus-separated values)
         assignee : str, optional
-            Username of the assignee
+            Username of the assignee (supports @me for current user)
         status : str, optional
             Task status (Open, Resolved, etc.)
         priority : str, optional
             Task priority (Unbreak, Triage, High, Normal, Low, Wish)
         subscribers : list, optional
-            List of subscriber usernames (may contain plus-separated values)
+            List of subscriber usernames (supports @me for current user)
+        column : str, optional
+            Column name on board for initial placement
+        board_phid : str, optional
+            Board PHID for column placement (required if column is specified)
         dry_run : bool
             If True, validate and display without creating
 
@@ -1620,13 +1626,23 @@ class Maniphest(Phabfive):
             validated_status = self._validate_status(status)
             transactions.append({"type": "status", "value": validated_status})
 
-        # Resolve assignee username to PHID
+        # Resolve assignee username to PHID (supports @me shortcut)
+        assignee_display = assignee
         if assignee:
-            assignee_phid = self._resolve_user_phid(assignee)
-            if not assignee_phid:
-                raise PhabfiveConfigException(
-                    f"User '{assignee}' not found on Phabricator"
-                )
+            if assignee == "@me":
+                whoami = self.phab.user.whoami()
+                assignee_phid = whoami.get("phid")
+                assignee_display = whoami.get("userName", "@me")
+                if not assignee_phid:
+                    raise PhabfiveConfigException(
+                        "Failed to get current user's PHID"
+                    )
+            else:
+                assignee_phid = self._resolve_user_phid(assignee)
+                if not assignee_phid:
+                    raise PhabfiveConfigException(
+                        f"User '{assignee}' not found on Phabricator"
+                    )
             transactions.append({"type": "owner", "value": assignee_phid})
 
         # Resolve project tags to PHIDs and slugs
@@ -1639,13 +1655,33 @@ class Maniphest(Phabfive):
                 )
                 project_slugs = project_info["slugs"]
 
-        # Resolve subscriber usernames to PHIDs
+        # Resolve subscriber usernames to PHIDs (supports @me shortcut)
+        subscriber_display = []
         if parsed_subscribers:
-            subscriber_phids = self._resolve_user_phids(parsed_subscribers)
+            subscriber_phids = []
+            for sub in parsed_subscribers:
+                if sub == "@me":
+                    whoami = self.phab.user.whoami()
+                    phid = whoami.get("phid")
+                    display_name = whoami.get("userName", "@me")
+                    if not phid:
+                        raise PhabfiveConfigException(
+                            "Failed to get current user's PHID"
+                        )
+                    subscriber_phids.append(phid)
+                    subscriber_display.append(display_name)
+                else:
+                    phid = self._resolve_user_phid(sub)
+                    if not phid:
+                        raise PhabfiveConfigException(f"User '{sub}' not found")
+                    subscriber_phids.append(phid)
+                    subscriber_display.append(sub)
             if subscriber_phids:
                 transactions.append(
                     {"type": "subscribers.set", "value": subscriber_phids}
                 )
+        else:
+            subscriber_display = parsed_subscribers
 
         # Dry run - return what would be created
         if dry_run:
@@ -1656,9 +1692,10 @@ class Maniphest(Phabfive):
                 "description": description,
                 "priority": priority,
                 "status": status,
-                "assignee": assignee,
+                "assignee": assignee_display,
                 "tags": parsed_tags,
-                "subscribers": parsed_subscribers,
+                "column": column,
+                "subscribers": subscriber_display,
             }
 
         # Create the task via API
@@ -1674,6 +1711,17 @@ class Maniphest(Phabfive):
             # Extract base URL from task URI for building tag URLs
             # e.g., "http://phorge.domain.tld/T5" -> "http://phorge.domain.tld"
             base_url = task_uri.rsplit("/", 1)[0] if "/" in task_uri else self.url
+
+            # Move task to specified column if requested
+            if column and board_phid:
+                task_data = self._get_task_data(task_id)
+                column_phid = self._navigate_column(
+                    task_id, task_data, column, board_phid
+                )
+                self.phab.maniphest.edit(
+                    objectIdentifier=f"T{task_id}",
+                    transactions=[{"type": "column", "value": [column_phid]}],
+                )
 
             return {
                 "phid": task_object["phid"],


### PR DESCRIPTION
## Summary

Enhance `phabfive maniphest create` with similar UX patterns as `phabfive maniphest edit`:

- Add `--force` flag to skip confirmation prompts
- Add `@me` shortcut for `--assign` and `--subscribe` options
- Add `--description -` to read description from stdin
- Add `$EDITOR` support when `--description` is omitted (interactive mode)
- Add `--column` option for initial board placement (requires `--tag`)
- Add descriptive prefix to editor temp files (`/tmp/description-abc123.remarkup`)
- Update help text for consistency with edit command
- Unify `--dry-run` output format between create and edit commands:
  - Create: `[DRY RUN] Would create task:` with indented fields
  - Edit: Human-readable changes with `old → new` format
  - Multi-line descriptions displayed with proper indentation

## Test plan

- [x] All 384 tests passing
- [x] `phabfive maniphest create "Test" --assign=@me --dry-run` resolves current user
- [x] `echo "desc" | phabfive maniphest create "Test" --description=- --dry-run` reads from stdin
- [x] `phabfive maniphest create "Test"` opens $EDITOR, shows description, confirms
- [x] `phabfive maniphest create "Test" --tag=Board --column=Backlog --dry-run` shows column
- [x] Help text shows `@me` in --assign and --subscribe options
- [x] Multi-line descriptions in `--dry-run` display with proper indentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)