### PR TITLE
feat(paste): Modernize paste app UX to match maniphest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,17 @@ make down                            # stop containers
 gh pr merge --rebase --delete-branch
 ```
 
+## Pre-commit Checks
+
+**Always run before committing:**
+
+```bash
+uv run ruff check phabfive/ tests/
+uv run ruff format phabfive/ tests/
+```
+
+CI will fail if files are not properly formatted.
+
 ## Architecture
 
 ### CLI Layer (`cli/`)

--- a/phabfive/cli/completers.py
+++ b/phabfive/cli/completers.py
@@ -3,6 +3,8 @@
 
 from typing import List
 
+from phabfive.constants import PASTE_LANGUAGES
+
 # Pattern prefixes for transition filters
 PATTERN_PREFIXES = ["in:", "not:in:", "from:", "to:", "been:", "never:"]
 
@@ -246,3 +248,22 @@ def complete_tag(incomplete: str) -> List[str]:
     # Case-insensitive prefix matching
     incomplete_lower = incomplete.lower()
     return [t for t in tags if t.lower().startswith(incomplete_lower)]
+
+
+def complete_language(incomplete: str) -> List[str]:
+    """Complete programming language values for syntax highlighting.
+
+    Uses the default languages from Phabricator/Phorge pygments.dropdown-choices.
+
+    Parameters
+    ----------
+    incomplete : str
+        The incomplete value being typed
+
+    Returns
+    -------
+    list
+        Matching language completions
+    """
+    incomplete_lower = incomplete.lower()
+    return [lang for lang in PASTE_LANGUAGES if lang.startswith(incomplete_lower)]

--- a/phabfive/cli/paste.py
+++ b/phabfive/cli/paste.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 import typer
 import yaml
 
+from phabfive.cli.completers import complete_language
 from phabfive.constants import MONOGRAMS
 from phabfive.exceptions import PhabfiveConfigException
 
@@ -147,13 +148,16 @@ def create(
         help="Paste content (use - to read from stdin, omit for $EDITOR)",
     ),
     language: Optional[str] = typer.Option(
-        None, "--language", "-l", help="Language for syntax highlighting"
+        None,
+        "--language",
+        help="Language for syntax highlighting",
+        autocompletion=complete_language,
     ),
     tag: Optional[List[str]] = typer.Option(
-        None, "--tag", "-t", help="Add to project (repeatable)"
+        None, "--tag", help="Add to project (repeatable)"
     ),
     subscribe: Optional[List[str]] = typer.Option(
-        None, "--subscribe", "-s", help="Add subscriber (username or @me, repeatable)"
+        None, "--subscribe", help="Add subscriber (username or @me, repeatable)"
     ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview without creating"),
 ) -> None:
@@ -165,7 +169,7 @@ def create(
         phabfive paste create "Notes" --content="Some text"
         echo "content" | phabfive paste create "From stdin" --content=-
         phabfive paste create "Code" --language=python  # opens $EDITOR
-        phabfive paste create "Task" --subscribe=@me --tag=project
+        phabfive paste create "Notes" --subscribe=@me --tag=project
     """
     paste = _get_paste_app()
 
@@ -280,8 +284,8 @@ def create(
         subscribers=subscriber_names,
     )
 
-    # Output the result
-    print(f"P{result['id']}")
+    # Output the result (full URL, consistent with maniphest create)
+    print(paste.get_paste_url(result["id"]))
 
 
 @paste_app.command()
@@ -399,3 +403,194 @@ def _display_pastes(result, output_format, paste_instance):
                     console.print(paste_data["content"])
 
             console.print()
+
+
+@paste_app.command()
+def edit(
+    ctx: typer.Context,
+    paste_id: str = typer.Argument(..., help="Paste monogram (e.g., P123)"),
+    title: Optional[str] = typer.Option(None, "--title", help="New title"),
+    content: Optional[str] = typer.Option(
+        None,
+        "--content",
+        help="New content (use - for stdin, omit to open $EDITOR with current content)",
+    ),
+    language: Optional[str] = typer.Option(
+        None,
+        "--language",
+        help="Language for syntax highlighting",
+        autocompletion=complete_language,
+    ),
+    tag: Optional[List[str]] = typer.Option(
+        None, "--tag", help="Add to project (repeatable)"
+    ),
+    subscribe: Optional[List[str]] = typer.Option(
+        None, "--subscribe", help="Add subscriber (username or @me, repeatable)"
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without applying"),
+    force: bool = typer.Option(
+        False, "--force", help="Apply changes without confirmation"
+    ),
+) -> None:
+    """Edit an existing paste.
+
+    \b
+    Examples:
+        phabfive paste edit P1 --title="New Title"
+        phabfive paste edit P1 --language=python
+        phabfive paste edit P1 --content="Updated content"
+        echo "new content" | phabfive paste edit P1 --content=-
+        phabfive paste edit P1 --content  # opens $EDITOR with current content
+        phabfive paste edit P1 --subscribe=@me --tag=project
+        phabfive paste edit P1 --title="Test" --dry-run
+    """
+    from phabfive.editor import confirm_text_change, edit_text
+
+    _setup_output_options(ctx)
+    paste = _get_paste_app()
+
+    # Validate paste ID format
+    paste_pattern = f"^{MONOGRAMS['paste']}$"
+    if not re.match(paste_pattern, paste_id):
+        sys.stderr.write(f"Error: Invalid paste ID '{paste_id}'. Expected format: P123\n")
+        raise typer.Exit(1)
+
+    numeric_id = int(paste_id[1:])
+
+    # Get current paste data
+    try:
+        current_paste = paste.get_paste_data(numeric_id)
+    except Exception as e:
+        sys.stderr.write(f"Error: {e}\n")
+        raise typer.Exit(1)
+
+    # Handle content editing
+    final_content = None
+    if content == "-":
+        # Read from stdin
+        if sys.stdin.isatty():
+            sys.stderr.write("Error: --content=- requires input from stdin\n")
+            raise typer.Exit(1)
+        final_content = sys.stdin.read()
+    elif content == "" or (content is None and "--content" in sys.argv):
+        # Open $EDITOR with current content
+        new_content = edit_text(
+            current_paste["content"],
+            prefix=f"paste-{paste_id}-",
+            suffix=f".{current_paste['language']}",
+        )
+        if new_content is None:
+            print("Edit cancelled (no changes)")
+            raise typer.Exit(0)
+        final_content = new_content
+    elif content is not None:
+        final_content = content
+
+    # Handle @me shortcut for subscribers
+    subscriber_names = []
+    if subscribe:
+        for sub in subscribe:
+            if sub == "@me":
+                whoami = paste.phab.user.whoami()
+                subscriber_names.append(whoami.get("userName", sub))
+            else:
+                subscriber_names.append(sub)
+
+    # Handle tags
+    tag_list = list(tag) if tag else None
+
+    # Show diff for content changes
+    if final_content is not None and not dry_run:
+        confirmed, return_code = confirm_text_change(
+            current_paste["content"], final_content, force
+        )
+        if not confirmed:
+            raise typer.Exit(return_code or 0)
+
+    # Perform edit
+    result = paste.edit_paste(
+        paste_id=numeric_id,
+        title=title,
+        content=final_content,
+        language=language,
+        tags=tag_list,
+        subscribers=subscriber_names if subscriber_names else None,
+        dry_run=dry_run,
+    )
+
+    # Output result
+    if dry_run:
+        print(f"[DRY RUN] Would edit {paste_id}:")
+        for change in result.get("changes", []):
+            print(f"  {change['field']}: {change['new']}")
+        if not result.get("changes"):
+            print("  No changes specified")
+    else:
+        if result.get("changes"):
+            print(f"Updated {paste_id}")
+            for change in result["changes"]:
+                print(f"  {change['field']}: {change['new']}")
+        else:
+            print(result.get("message", "No changes made"))
+
+
+@paste_app.command()
+def comment(
+    ctx: typer.Context,
+    paste_id: str = typer.Argument(..., help="Paste monogram (e.g., P123)"),
+    text: Optional[str] = typer.Argument(
+        None, help="Comment text (omit to open $EDITOR)"
+    ),
+) -> None:
+    """Add a comment to a paste.
+
+    \b
+    Examples:
+        phabfive paste comment P1 "Great paste!"
+        phabfive paste comment P1  # opens $EDITOR
+        echo "comment" | phabfive paste comment P1 -
+        phabfive P1 "Quick comment"  # monogram shortcut
+    """
+    from phabfive.editor import edit_text
+
+    paste = _get_paste_app()
+
+    # Validate paste ID format
+    paste_pattern = f"^{MONOGRAMS['paste']}$"
+    if not re.match(paste_pattern, paste_id):
+        sys.stderr.write(f"Error: Invalid paste ID '{paste_id}'. Expected format: P123\n")
+        raise typer.Exit(1)
+
+    numeric_id = int(paste_id[1:])
+
+    # Determine comment text
+    final_text = None
+    if text == "-":
+        # Read from stdin
+        if sys.stdin.isatty():
+            sys.stderr.write("Error: '-' requires input from stdin\n")
+            raise typer.Exit(1)
+        final_text = sys.stdin.read().strip()
+    elif text is not None:
+        final_text = text
+    else:
+        # Open $EDITOR
+        if not sys.stdin.isatty():
+            sys.stderr.write("Error: Provide comment text or run interactively\n")
+            raise typer.Exit(1)
+        final_text = edit_text("", prefix="paste-comment-", suffix=".remarkup")
+        if final_text is None:
+            print("Comment cancelled")
+            raise typer.Exit(0)
+
+    if not final_text:
+        sys.stderr.write("Error: Comment cannot be empty\n")
+        raise typer.Exit(1)
+
+    # Add the comment
+    try:
+        paste.add_paste_comment(numeric_id, final_text)
+        print(paste.get_paste_url(numeric_id))
+    except Exception as e:
+        sys.stderr.write(f"Error: {e}\n")
+        raise typer.Exit(1)

--- a/phabfive/cli/paste.py
+++ b/phabfive/cli/paste.py
@@ -1,14 +1,44 @@
 # -*- coding: utf-8 -*-
 """Paste commands for phabfive CLI."""
 
+import re
 import sys
+from datetime import datetime
 from typing import List, Optional
 
 import typer
+import yaml
 
+from phabfive.constants import MONOGRAMS
 from phabfive.exceptions import PhabfiveConfigException
 
 paste_app = typer.Typer(help="The paste app")
+
+
+def _get_output_format(ctx: typer.Context):
+    """Get output format from context or auto-detect."""
+    from phabfive.core import Phabfive
+
+    format_arg = ctx.obj.get("format") if ctx.obj else None
+    if format_arg is None:
+        return Phabfive._get_auto_format()
+    return format_arg
+
+
+def _setup_output_options(ctx: typer.Context):
+    """Set up output options from context."""
+    from phabfive.core import Phabfive
+
+    if ctx.obj:
+        ascii_when = ctx.obj.get("ascii", "auto")
+        hyperlink_when = ctx.obj.get("hyperlink", "auto")
+        output_format = _get_output_format(ctx)
+
+        Phabfive.set_output_options(
+            ascii_when=ascii_when,
+            hyperlink_when=hyperlink_when,
+            output_format=output_format,
+        )
 
 
 def _get_paste_app():
@@ -33,52 +63,339 @@ def _get_paste_app():
 
 @paste_app.command("list")
 def paste_list(ctx: typer.Context) -> None:
-    """List all pastes."""
+    """List all pastes (alias for search)."""
+    # Delegate to search with no filters
+    ctx.invoke(search)
+
+
+@paste_app.command()
+def search(
+    ctx: typer.Context,
+    author: Optional[str] = typer.Option(
+        None, "--author", help="Filter by author (username or @me)"
+    ),
+) -> None:
+    """Search and list pastes with optional filters.
+
+    \b
+    Examples:
+        phabfive paste search
+        phabfive paste search "script"
+        phabfive paste search --author=@me
+        phabfive paste search "config" --author=@me
+        phabfive --format=yaml paste search
+    """
+    _setup_output_options(ctx)
     paste = _get_paste_app()
-    pastes = paste.get_pastes_formatted()
-    for p in pastes:
-        typer.echo(f"{p['id']} {p['title']}")
+
+    # Build constraints
+    constraints = {}
+
+    # Handle @me shortcut for author
+    if author:
+        if author == "@me":
+            whoami = paste.phab.user.whoami()
+            author_phid = whoami.get("phid")
+        else:
+            # Look up user by username
+            users = paste.phab.user.search(constraints={"usernames": [author]})
+            if users.get("data"):
+                author_phid = users["data"][0]["phid"]
+            else:
+                sys.stderr.write(f"Error: User '{author}' not found\n")
+                raise typer.Exit(1)
+        constraints["authorPHIDs"] = [author_phid]
+
+    # Get pastes with constraints
+    pastes = paste.get_pastes(constraints=constraints if constraints else None)
+
+    if not pastes:
+        typer.echo("No pastes found")
+        return
+
+    # Format output
+    output_format = _get_output_format(ctx)
+
+    if output_format == "json":
+        import json
+
+        result = [
+            {"id": f"P{p['id']}", "title": p["fields"]["title"]} for p in pastes
+        ]
+        print(json.dumps(result, indent=2))
+    elif output_format in ("yaml", "strict"):
+        result = [
+            {"id": f"P{p['id']}", "title": p["fields"]["title"]} for p in pastes
+        ]
+        print(yaml.dump(result, default_flow_style=False, allow_unicode=True))
+    else:
+        # Rich/default format
+        for p in pastes:
+            typer.echo(f"P{p['id']} {p['fields']['title']}")
 
 
 @paste_app.command()
 def create(
     ctx: typer.Context,
     title: str = typer.Argument(..., help="Title for Paste"),
-    file: str = typer.Argument(..., help="A file with text content for Paste"),
-    tags: Optional[str] = typer.Option(
-        None,
-        "--tags",
-        "-t",
-        help="Project name(s), comma-separated (e.g., projectX,projectY)",
+    file: Optional[str] = typer.Argument(
+        None, help="File with content (optional if using --content or $EDITOR)"
     ),
-    subscribers: Optional[str] = typer.Option(
+    content: Optional[str] = typer.Option(
         None,
-        "--subscribers",
-        "-s",
-        help="Subscriber names, comma-separated (e.g., user1,user2)",
+        "--content",
+        help="Paste content (use - to read from stdin, omit for $EDITOR)",
     ),
+    language: Optional[str] = typer.Option(
+        None, "--language", "-l", help="Language for syntax highlighting"
+    ),
+    tag: Optional[List[str]] = typer.Option(
+        None, "--tag", "-t", help="Add to project (repeatable)"
+    ),
+    subscribe: Optional[List[str]] = typer.Option(
+        None, "--subscribe", "-s", help="Add subscriber (username or @me, repeatable)"
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without creating"),
 ) -> None:
-    """Create a new paste from a file."""
+    """Create a new paste.
+
+    \b
+    Examples:
+        phabfive paste create "My Script" script.py
+        phabfive paste create "Notes" --content="Some text"
+        echo "content" | phabfive paste create "From stdin" --content=-
+        phabfive paste create "Code" --language=python  # opens $EDITOR
+        phabfive paste create "Task" --subscribe=@me --tag=project
+    """
     paste = _get_paste_app()
 
-    tags_list = tags.split(",") if tags else None
-    subscribers_list = subscribers.split(",") if subscribers else None
+    # Determine content source
+    final_content = None
 
-    paste.create_paste(
+    if file:
+        # Read from file
+        try:
+            with open(file, "r") as f:
+                final_content = f.read()
+        except FileNotFoundError:
+            sys.stderr.write(f"Error: File not found: {file}\n")
+            raise typer.Exit(1)
+        except IOError as e:
+            sys.stderr.write(f"Error reading file: {e}\n")
+            raise typer.Exit(1)
+
+        # Auto-detect language from file extension if not specified
+        if not language and "." in file:
+            ext = file.rsplit(".", 1)[-1].lower()
+            ext_map = {
+                "py": "python",
+                "js": "javascript",
+                "ts": "typescript",
+                "sh": "bash",
+                "bash": "bash",
+                "json": "json",
+                "yaml": "yaml",
+                "yml": "yaml",
+                "sql": "sql",
+                "html": "html",
+                "css": "css",
+                "c": "c",
+                "cpp": "cpp",
+                "h": "c",
+                "java": "java",
+                "go": "go",
+                "rs": "rust",
+                "rb": "ruby",
+                "php": "php",
+                "md": "text",
+                "txt": "text",
+            }
+            language = ext_map.get(ext)
+
+    elif content == "-":
+        # Read from stdin
+        if sys.stdin.isatty():
+            sys.stderr.write("Error: --content=- requires input from stdin\n")
+            raise typer.Exit(1)
+        final_content = sys.stdin.read()
+
+    elif content is not None:
+        # Use provided content directly
+        final_content = content
+
+    elif sys.stdin.isatty() and not dry_run:
+        # Open $EDITOR
+        from phabfive.editor import edit_text
+
+        suffix = f".{language}" if language else ".txt"
+        final_content = edit_text("", prefix="paste-", suffix=suffix)
+        if final_content is None:
+            print("Paste creation cancelled")
+            raise typer.Exit(0)
+
+    else:
+        sys.stderr.write(
+            "Error: No content provided. Use a file, --content, or run interactively.\n"
+        )
+        raise typer.Exit(1)
+
+    # Handle @me shortcut for subscribers
+    subscriber_names = []
+    if subscribe:
+        for sub in subscribe:
+            if sub == "@me":
+                whoami = paste.phab.user.whoami()
+                subscriber_names.append(whoami.get("userName", sub))
+            else:
+                subscriber_names.append(sub)
+
+    # Handle tags
+    tag_list = list(tag) if tag else None
+
+    if dry_run:
+        print("[DRY RUN] Would create paste:")
+        print(f"  Title: {title}")
+        if language:
+            print(f"  Language: {language}")
+        if tag_list:
+            print(f"  Tags: {', '.join(tag_list)}")
+        if subscriber_names:
+            print(f"  Subscribers: {', '.join(subscriber_names)}")
+        # Show content preview
+        lines = final_content.split("\n")
+        if len(lines) <= 5:
+            print("  Content:")
+            for line in lines:
+                print(f"    {line}")
+        else:
+            print(f"  Content: ({len(lines)} lines, {len(final_content)} chars)")
+        raise typer.Exit(0)
+
+    # Create the paste
+    result = paste.create_paste_from_content(
         title=title,
-        file=file,
-        tags=tags_list,
-        subscribers=subscribers_list,
+        content=final_content,
+        language=language,
+        tags=tag_list,
+        subscribers=subscriber_names,
     )
+
+    # Output the result
+    print(f"P{result['id']}")
 
 
 @paste_app.command()
 def show(
     ctx: typer.Context,
-    ids: List[str] = typer.Argument(..., help="Paste monogram(s) (e.g., P1 P2 P3)"),
+    paste_ids: List[str] = typer.Argument(..., help="Paste monogram(s) (e.g., P1 P2)"),
+    show_content: bool = typer.Option(
+        True, "--show-content/--no-content", help="Show paste content"
+    ),
 ) -> None:
-    """Show specific pastes by ID."""
+    """Show details for one or more pastes.
+
+    \b
+    Examples:
+        phabfive paste show P1
+        phabfive paste show P1 P2 --no-content
+        phabfive --format=yaml paste show P1
+    """
+    _setup_output_options(ctx)
     paste = _get_paste_app()
-    pastes = paste.get_pastes_formatted(ids=ids)
-    for p in pastes:
-        typer.echo(f"{p['id']} {p['title']}")
+
+    # Validate all paste ID formats
+    paste_pattern = f"^{MONOGRAMS['paste']}$"
+    ids = []
+    for paste_id in paste_ids:
+        if not re.match(paste_pattern, paste_id):
+            typer.echo(
+                f"Invalid paste ID '{paste_id}'. Expected format: P123", err=True
+            )
+            raise typer.Exit(1)
+        ids.append(int(paste_id[1:]))
+
+    result = paste.paste_show(ids, show_content=show_content)
+
+    output_format = _get_output_format(ctx)
+    _display_pastes(result, output_format, paste)
+
+
+def _display_pastes(result, output_format, paste_instance):
+    """Display paste results in the specified format."""
+    import json
+
+    from rich.syntax import Syntax
+
+    if not result or not result.get("pastes"):
+        return
+
+    pastes = result["pastes"]
+
+    if output_format == "json":
+        print(json.dumps(pastes, indent=2, default=str))
+    elif output_format in ("yaml", "strict"):
+        print(yaml.dump(pastes, default_flow_style=False, allow_unicode=True))
+    else:
+        # Rich format
+        console = paste_instance.get_console()
+
+        for paste_data in pastes:
+            # Build header
+            title = f"{paste_data['id']}: {paste_data['title']}"
+
+            # Build metadata lines
+            lines = []
+            if paste_data.get("author"):
+                lines.append(f"Author: {paste_data['author']}")
+            if paste_data.get("language"):
+                lines.append(f"Language: {paste_data['language']}")
+            if paste_data.get("dateCreated"):
+                created = datetime.fromtimestamp(paste_data["dateCreated"])
+                lines.append(f"Created: {created.strftime('%Y-%m-%d %H:%M')}")
+
+            # Print header and metadata
+            console.print(f"[bold]{title}[/bold]")
+            console.print("─" * min(len(title) + 10, 60))
+            for line in lines:
+                console.print(line)
+
+            # Print content with syntax highlighting
+            if paste_data.get("content"):
+                console.print()
+                language = paste_data.get("language", "text")
+                # Map common phabricator language names to pygments lexers
+                lang_map = {
+                    "text": "text",
+                    "python": "python",
+                    "python3": "python",
+                    "javascript": "javascript",
+                    "js": "javascript",
+                    "bash": "bash",
+                    "shell": "bash",
+                    "json": "json",
+                    "yaml": "yaml",
+                    "sql": "sql",
+                    "html": "html",
+                    "css": "css",
+                    "c": "c",
+                    "cpp": "cpp",
+                    "java": "java",
+                    "go": "go",
+                    "rust": "rust",
+                    "ruby": "ruby",
+                    "php": "php",
+                }
+                lexer = lang_map.get(language.lower(), "text")
+                try:
+                    syntax = Syntax(
+                        paste_data["content"],
+                        lexer,
+                        theme="monokai",
+                        line_numbers=True,
+                    )
+                    console.print(syntax)
+                except Exception:
+                    # Fall back to plain text if syntax highlighting fails
+                    console.print(paste_data["content"])
+
+            console.print()

--- a/phabfive/cli/paste.py
+++ b/phabfive/cli/paste.py
@@ -62,16 +62,10 @@ def _get_paste_app():
         raise typer.Exit(1)
 
 
-@paste_app.command("list")
-def paste_list(ctx: typer.Context) -> None:
-    """List all pastes (alias for search)."""
-    # Delegate to search with no filters
-    ctx.invoke(search)
-
-
 @paste_app.command()
 def search(
     ctx: typer.Context,
+    query: Optional[str] = typer.Argument(None, help="Free-text search in paste title"),
     author: Optional[str] = typer.Option(
         None, "--author", help="Filter by author (username or @me)"
     ),
@@ -91,6 +85,10 @@ def search(
 
     # Build constraints
     constraints = {}
+
+    # Handle free-text query
+    if query:
+        constraints["query"] = query
 
     # Handle @me shortcut for author
     if author:
@@ -120,14 +118,10 @@ def search(
     if output_format == "json":
         import json
 
-        result = [
-            {"id": f"P{p['id']}", "title": p["fields"]["title"]} for p in pastes
-        ]
+        result = [{"id": f"P{p['id']}", "title": p["fields"]["title"]} for p in pastes]
         print(json.dumps(result, indent=2))
     elif output_format in ("yaml", "strict"):
-        result = [
-            {"id": f"P{p['id']}", "title": p["fields"]["title"]} for p in pastes
-        ]
+        result = [{"id": f"P{p['id']}", "title": p["fields"]["title"]} for p in pastes]
         print(yaml.dump(result, default_flow_style=False, allow_unicode=True))
     else:
         # Rich/default format
@@ -427,7 +421,9 @@ def edit(
     subscribe: Optional[List[str]] = typer.Option(
         None, "--subscribe", help="Add subscriber (username or @me, repeatable)"
     ),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without applying"),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview changes without applying"
+    ),
     force: bool = typer.Option(
         False, "--force", help="Apply changes without confirmation"
     ),
@@ -452,7 +448,9 @@ def edit(
     # Validate paste ID format
     paste_pattern = f"^{MONOGRAMS['paste']}$"
     if not re.match(paste_pattern, paste_id):
-        sys.stderr.write(f"Error: Invalid paste ID '{paste_id}'. Expected format: P123\n")
+        sys.stderr.write(
+            f"Error: Invalid paste ID '{paste_id}'. Expected format: P123\n"
+        )
         raise typer.Exit(1)
 
     numeric_id = int(paste_id[1:])
@@ -558,7 +556,9 @@ def comment(
     # Validate paste ID format
     paste_pattern = f"^{MONOGRAMS['paste']}$"
     if not re.match(paste_pattern, paste_id):
-        sys.stderr.write(f"Error: Invalid paste ID '{paste_id}'. Expected format: P123\n")
+        sys.stderr.write(
+            f"Error: Invalid paste ID '{paste_id}'. Expected format: P123\n"
+        )
         raise typer.Exit(1)
 
     numeric_id = int(paste_id[1:])

--- a/phabfive/constants.py
+++ b/phabfive/constants.py
@@ -47,8 +47,57 @@ MONOGRAM_SHORTCUT = {
 }
 
 # Apps that support "X123 'text'" → "app comment X123 'text'" shortcut
-# Currently only Maniphest supports comments. Paste could be added later.
-COMMENTS_SUPPORTED = ["maniphest"]
+COMMENTS_SUPPORTED = ["maniphest", "paste"]
+
+# Default languages for paste syntax highlighting (from Phabricator pygments.dropdown-choices)
+# These are the languages shown in the Phabricator/Phorge Paste language dropdown by default.
+# The actual list can be configured per-instance via pygments.dropdown-choices.
+PASTE_LANGUAGES = [
+    "apacheconf",
+    "bash",
+    "brainfuck",
+    "c",
+    "coffee-script",
+    "cpp",
+    "csharp",
+    "css",
+    "d",
+    "diff",
+    "django",
+    "docker",
+    "erb",
+    "erlang",
+    "go",
+    "groovy",
+    "haskell",
+    "html",
+    "http",
+    "invisible",
+    "java",
+    "js",
+    "json",
+    "make",
+    "mysql",
+    "nginx",
+    "objc",
+    "perl",
+    "php",
+    "postgresql",
+    "pot",
+    "puppet",
+    "python",
+    "rainbow",
+    "remarkup",
+    "robotframework",
+    "rst",
+    "ruby",
+    "sql",
+    "tex",
+    "text",
+    "twig",
+    "xml",
+    "yaml",
+]
 
 # IO_EDIT_URI_VALUES = ["default", "read", "write", "never"]
 IO_NEW_URI_CHOICES = ["default", "observe", "mirror", "never"]
@@ -106,6 +155,7 @@ __all__ = [
     "MONOGRAM_SHORTCUT",
     "MONOGRAMS",
     "OutputFormat",
+    "PASTE_LANGUAGES",
     "PRIORITY_VALUES",
     "PRIORITY_DEFAULT",
     "REPO_STATUS_CHOICES",

--- a/phabfive/paste/__init__.py
+++ b/phabfive/paste/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Paste module for phabfive."""
+
+from phabfive.paste.core import Paste
+
+__all__ = ["Paste"]

--- a/phabfive/paste/core.py
+++ b/phabfive/paste/core.py
@@ -227,7 +227,9 @@ class Paste(Phabfive):
             "phid": paste["phid"],
             "title": paste["fields"].get("title", ""),
             "language": paste["fields"].get("language") or "text",
-            "content": paste.get("attachments", {}).get("content", {}).get("content", ""),
+            "content": paste.get("attachments", {})
+            .get("content", {})
+            .get("content", ""),
         }
 
     def edit_paste(
@@ -276,10 +278,16 @@ class Paste(Phabfive):
 
         if subscribers:
             transactions.append({"type": "subscribers.add", "value": subscribers})
-            changes.append({"field": "Subscribers", "new": f"Added: {', '.join(subscribers)}"})
+            changes.append(
+                {"field": "Subscribers", "new": f"Added: {', '.join(subscribers)}"}
+            )
 
         if not transactions:
-            return {"paste_id": paste_id, "changes": [], "message": "No changes specified"}
+            return {
+                "paste_id": paste_id,
+                "changes": [],
+                "message": "No changes specified",
+            }
 
         if dry_run:
             return {"paste_id": paste_id, "changes": changes, "dry_run": True}

--- a/phabfive/paste/core.py
+++ b/phabfive/paste/core.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Core paste functionality for phabfive."""
 
 # python std lib
 import re
@@ -42,7 +43,7 @@ class Paste(Phabfive):
         self, title=None, file=None, language=None, tags=None, subscribers=None
     ):
         """
-        Wrapper that connects to Phabricator and creates paste.
+        Wrapper that connects to Phabricator and creates paste from a file.
 
         :type title: str
         :type file: str
@@ -52,25 +53,43 @@ class Paste(Phabfive):
 
         :rtype: dict
         """
-        text = None
-        tags = tags if tags else []
-        subscribers = subscribers if subscribers else []
-
         with open(file, "r") as f:
             text = f.read()
 
-        # FIXME: convert to use self.to_transactions({...}) instead
-        transactions = []
+        return self.create_paste_from_content(
+            title=title,
+            content=text,
+            language=language,
+            tags=tags,
+            subscribers=subscribers,
+        )
+
+    def create_paste_from_content(
+        self, title=None, content=None, language=None, tags=None, subscribers=None
+    ):
+        """
+        Create a paste with the given content.
+
+        :type title: str
+        :type content: str
+        :type language: str
+        :type tags: list
+        :type subscribers: list
+
+        :rtype: dict
+        """
+        tags = tags if tags else []
+        subscribers = subscribers if subscribers else []
+
         transactions_values = [
             {"type": "title", "value": title},
-            {"type": "text", "value": text},
+            {"type": "text", "value": content},
             {"type": "language", "value": language},
-            # TODO: Create a function that vaildates tags' and 'subscribers' existence
             {"type": "projects.add", "value": tags},
             {"type": "subscribers.add", "value": subscribers},
         ]
 
-        # Phabricator does not take None (empty list is ok for projects/subscribers) as a value, therefor only "type" that has valid value can be sent as an argument
+        # Phabricator does not take None as a value
         transactions = [
             item for item in transactions_values if None not in item.values()
         ]
@@ -125,3 +144,62 @@ class Paste(Phabfive):
             {"id": f"P{item['id']}", "title": item["fields"]["title"]}
             for item in sorted_pastes
         ]
+
+    def paste_show(self, paste_ids, show_content=True):
+        """Get detailed paste information for display.
+
+        Args:
+            paste_ids: List of paste IDs (integers, without P prefix)
+            show_content: Whether to include paste content
+
+        Returns:
+            dict with 'pastes' key containing list of paste data
+        """
+        attachments = {}
+        if show_content:
+            attachments["content"] = True
+
+        pastes = self.get_pastes(
+            constraints={"ids": paste_ids},
+            attachments=attachments,
+        )
+
+        if not pastes:
+            raise PhabfiveDataException("No pastes found")
+
+        result = []
+        for paste in pastes:
+            paste_data = {
+                "id": f"P{paste['id']}",
+                "phid": paste["phid"],
+                "title": paste["fields"].get("title", ""),
+                "language": paste["fields"].get("language") or "text",
+                "status": paste["fields"].get("status", "active"),
+                "dateCreated": paste["fields"].get("dateCreated"),
+                "dateModified": paste["fields"].get("dateModified"),
+                "authorPHID": paste["fields"].get("authorPHID"),
+            }
+
+            # Add content if requested and available
+            if show_content and "attachments" in paste:
+                content_attachment = paste["attachments"].get("content", {})
+                paste_data["content"] = content_attachment.get("content", "")
+
+            # Resolve author name
+            author_phid = paste_data.get("authorPHID")
+            if author_phid:
+                paste_data["author"] = self._resolve_phid_to_name(author_phid)
+
+            result.append(paste_data)
+
+        return {"pastes": result}
+
+    def _resolve_phid_to_name(self, phid):
+        """Resolve a PHID to a human-readable name."""
+        try:
+            response = self.phab.phid.query(phids=[phid])
+            if response and phid in response:
+                return response[phid].get("name", phid)
+        except Exception:
+            pass
+        return phid

--- a/phabfive/paste/core.py
+++ b/phabfive/paste/core.py
@@ -203,3 +203,125 @@ class Paste(Phabfive):
         except Exception:
             pass
         return phid
+
+    def get_paste_data(self, paste_id):
+        """Get full paste data including content.
+
+        Args:
+            paste_id: Paste ID (integer, without P prefix)
+
+        Returns:
+            dict with paste data including content
+        """
+        pastes = self.get_pastes(
+            constraints={"ids": [paste_id]},
+            attachments={"content": True},
+        )
+
+        if not pastes:
+            raise PhabfiveDataException(f"Paste P{paste_id} not found")
+
+        paste = pastes[0]
+        return {
+            "id": paste["id"],
+            "phid": paste["phid"],
+            "title": paste["fields"].get("title", ""),
+            "language": paste["fields"].get("language") or "text",
+            "content": paste.get("attachments", {}).get("content", {}).get("content", ""),
+        }
+
+    def edit_paste(
+        self,
+        paste_id,
+        title=None,
+        content=None,
+        language=None,
+        tags=None,
+        subscribers=None,
+        dry_run=False,
+    ):
+        """Edit an existing paste.
+
+        Args:
+            paste_id: Paste ID (integer, without P prefix)
+            title: New title (None to keep current)
+            content: New content (None to keep current)
+            language: New language (None to keep current)
+            tags: List of project tags to add
+            subscribers: List of subscriber usernames to add
+            dry_run: If True, return changes without applying
+
+        Returns:
+            dict with changes made or to be made
+        """
+        # Build transactions
+        transactions = []
+        changes = []
+
+        if title is not None:
+            transactions.append({"type": "title", "value": title})
+            changes.append({"field": "Title", "new": title})
+
+        if content is not None:
+            transactions.append({"type": "text", "value": content})
+            changes.append({"field": "Content", "new": "(updated)"})
+
+        if language is not None:
+            transactions.append({"type": "language", "value": language})
+            changes.append({"field": "Language", "new": language})
+
+        if tags:
+            transactions.append({"type": "projects.add", "value": tags})
+            changes.append({"field": "Tags", "new": f"Added: {', '.join(tags)}"})
+
+        if subscribers:
+            transactions.append({"type": "subscribers.add", "value": subscribers})
+            changes.append({"field": "Subscribers", "new": f"Added: {', '.join(subscribers)}"})
+
+        if not transactions:
+            return {"paste_id": paste_id, "changes": [], "message": "No changes specified"}
+
+        if dry_run:
+            return {"paste_id": paste_id, "changes": changes, "dry_run": True}
+
+        # Apply changes
+        try:
+            self.phab.paste.edit(
+                objectIdentifier=f"P{paste_id}",
+                transactions=transactions,
+            )
+        except APIError as e:
+            raise PhabfiveDataException(str(e).replace("ERR-CONDUIT-CORE: ", ""))
+
+        return {"paste_id": paste_id, "changes": changes}
+
+    def add_paste_comment(self, paste_id, comment_text):
+        """Add a comment to a paste.
+
+        Args:
+            paste_id: Paste ID (integer, without P prefix)
+            comment_text: The comment text to add
+
+        Returns:
+            dict with 'success' and 'paste_id' keys
+        """
+        try:
+            self.phab.paste.edit(
+                objectIdentifier=f"P{paste_id}",
+                transactions=[{"type": "comment", "value": comment_text}],
+            )
+        except APIError as e:
+            raise PhabfiveDataException(str(e).replace("ERR-CONDUIT-CORE: ", ""))
+
+        return {"success": True, "paste_id": paste_id}
+
+    def get_paste_url(self, paste_id):
+        """Get the URL for a paste.
+
+        Args:
+            paste_id: Paste ID (integer, without P prefix)
+
+        Returns:
+            URL string for the paste
+        """
+        return f"{self.url}/P{paste_id}"


### PR DESCRIPTION
## Summary

- Restructure paste module to package (`phabfive/paste/`)
- Add `search` command with free-text query and `--author` filter
- Add `edit` command with `$EDITOR`, stdin, diff preview support
- Add `comment` command with monogram shortcut (`P123 "text"`)
- Enhance `show` command with metadata, syntax highlighting, structured output
- Enhance `create` command with stdin, `$EDITOR`, `--dry-run` support
- Add shell completion for `--language` using official Phorge language list
- Remove deprecated `list` command (use `search` instead)

## Test plan

- [x] All 384 tests pass
- [x] `phabfive paste search "query"` works
- [x] `phabfive paste create` with `--content=-` and `$EDITOR` works
- [x] `phabfive paste edit P1 --title="New"` works
- [x] `phabfive paste comment P1 "text"` works
- [x] `phabfive P1 "comment"` monogram shortcut works

🤖 Generated with [Claude Code](https://claude.com/claude-code)