### PR TITLE
feat(cli): Add positional title argument with diff display for edit commands

### DIFF
--- a/phabfive/cli/maniphest.py
+++ b/phabfive/cli/maniphest.py
@@ -540,6 +540,16 @@ def edit(
         ...,
         help="Task monogram(s) (e.g., T123 or T123,T124,T125)",
     ),
+    title: Optional[str] = typer.Argument(
+        None,
+        help="New title for the task",
+    ),
+    title_opt: Optional[str] = typer.Option(
+        None,
+        "--title",
+        hidden=True,
+        help="New title (hidden, use positional argument instead)",
+    ),
     priority: Optional[str] = typer.Option(
         None,
         "--priority",
@@ -599,11 +609,15 @@ def edit(
 
     \b
     Examples:
+        phabfive maniphest edit T123 "New Title"
         phabfive maniphest edit T123  # opens $EDITOR for description
         phabfive maniphest edit T123 --priority=high
         phabfive maniphest edit T123,T124 --status=resolved
         phabfive maniphest edit T123 --tag="Sprint" --column=forward
     """
+    # Merge positional and option title (positional takes precedence)
+    final_title = title or title_opt
+
     # Validate monogram format (T followed by digits)
     maniphest_pattern = f"^{MONOGRAMS['maniphest']}$"
     for part in task_ids.split(","):
@@ -619,6 +633,7 @@ def edit(
 
     retcode = edit_handler.edit_objects(
         object_id=task_ids,
+        title=final_title,
         priority=priority,
         status=status,
         tag=tag,

--- a/phabfive/cli/paste.py
+++ b/phabfive/cli/paste.py
@@ -403,7 +403,13 @@ def _display_pastes(result, output_format, paste_instance):
 def edit(
     ctx: typer.Context,
     paste_id: str = typer.Argument(..., help="Paste monogram (e.g., P123)"),
-    title: Optional[str] = typer.Option(None, "--title", help="New title"),
+    title: Optional[str] = typer.Argument(None, help="New title for the paste"),
+    title_opt: Optional[str] = typer.Option(
+        None,
+        "--title",
+        hidden=True,
+        help="New title (hidden, use positional argument instead)",
+    ),
     content: Optional[str] = typer.Option(
         None,
         "--content",
@@ -432,18 +438,21 @@ def edit(
 
     \b
     Examples:
-        phabfive paste edit P1 --title="New Title"
+        phabfive paste edit P1 "New Title"
         phabfive paste edit P1 --language=python
         phabfive paste edit P1 --content="Updated content"
         echo "new content" | phabfive paste edit P1 --content=-
         phabfive paste edit P1 --content  # opens $EDITOR with current content
         phabfive paste edit P1 --subscribe=@me --tag=project
-        phabfive paste edit P1 --title="Test" --dry-run
+        phabfive paste edit P1 "Test" --dry-run
     """
     from phabfive.editor import confirm_text_change, edit_text
 
     _setup_output_options(ctx)
     paste = _get_paste_app()
+
+    # Merge positional and option title (positional takes precedence)
+    final_title = title or title_opt
 
     # Validate paste ID format
     paste_pattern = f"^{MONOGRAMS['paste']}$"
@@ -508,7 +517,7 @@ def edit(
     # Perform edit
     result = paste.edit_paste(
         paste_id=numeric_id,
-        title=title,
+        title=final_title,
         content=final_content,
         language=language,
         tags=tag_list,

--- a/phabfive/cli/paste.py
+++ b/phabfive/cli/paste.py
@@ -514,6 +514,16 @@ def edit(
         if not confirmed:
             raise typer.Exit(return_code or 0)
 
+    # Show diff for title changes
+    if final_title is not None and not dry_run:
+        current_title = current_paste.get("title", "")
+        if final_title != current_title:
+            confirmed, return_code = confirm_text_change(
+                current_title, final_title, force, filename="title"
+            )
+            if not confirmed:
+                raise typer.Exit(return_code or 0)
+
     # Perform edit
     result = paste.edit_paste(
         paste_id=numeric_id,
@@ -527,9 +537,16 @@ def edit(
 
     # Output result
     if dry_run:
+        from phabfive.editor import show_diff
+
         print(f"[DRY RUN] Would edit {paste_id}:")
         for change in result.get("changes", []):
-            print(f"  {change['field']}: {change['new']}")
+            if change["field"] == "Title":
+                # Show unified diff for title
+                print()
+                show_diff(current_paste.get("title", ""), final_title, filename="title")
+            else:
+                print(f"  {change['field']}: {change['new']}")
         if not result.get("changes"):
             print("  No changes specified")
     else:

--- a/phabfive/edit/batch.py
+++ b/phabfive/edit/batch.py
@@ -18,6 +18,7 @@ log = logging.getLogger(__name__)
 def edit_tasks_batch(
     tasks,
     maniphest,
+    title=None,
     priority=None,
     status=None,
     tag=None,
@@ -33,6 +34,7 @@ def edit_tasks_batch(
     Args:
         tasks (list): List of task dicts with 'object_id' key
         maniphest: Maniphest instance for editing tasks
+        title (str): New title for the tasks
         priority (str): Priority to set (or "raise"/"lower")
         status (str): Status to set
         tag (str): Board name for column context
@@ -107,6 +109,7 @@ def edit_tasks_batch(
         try:
             result = maniphest.edit_task_by_id(
                 task_id=task["task_id"],
+                title=title,
                 priority=priority,
                 status=status,
                 board_phid=task["board_phid"],

--- a/phabfive/edit/core.py
+++ b/phabfive/edit/core.py
@@ -34,6 +34,7 @@ class Edit(Phabfive):
     def edit_objects(
         self,
         object_id=None,
+        title=None,
         priority=None,
         status=None,
         tag=None,
@@ -49,6 +50,7 @@ class Edit(Phabfive):
 
         Args:
             object_id (str): Object ID(s) - single (e.g., "T123") or comma-separated (e.g., "T123,T124")
+            title (str): New title for the object
             priority (str): Priority to set (or "raise"/"lower")
             status (str): Status to set
             tag (str): Board name for column context
@@ -66,6 +68,7 @@ class Edit(Phabfive):
         # If no edit options provided, default to editing description in $EDITOR
         has_any_option = any(
             [
+                title,
                 priority,
                 status,
                 column,
@@ -92,6 +95,7 @@ class Edit(Phabfive):
                     if object_type == "task":
                         return self._edit_task_single(
                             oid,
+                            title=title,
                             priority=priority,
                             status=status,
                             tag=tag,
@@ -133,6 +137,7 @@ class Edit(Phabfive):
                         return edit_tasks_batch(
                             tasks,
                             self.maniphest,
+                            title=title,
                             priority=priority,
                             status=status,
                             tag=tag,
@@ -176,6 +181,7 @@ class Edit(Phabfive):
                     retcode = edit_tasks_batch(
                         grouped["task"],
                         self.maniphest,
+                        title=title,
                         priority=priority,
                         status=status,
                         tag=tag,
@@ -217,6 +223,7 @@ class Edit(Phabfive):
     def _edit_task_single(
         self,
         task_id,
+        title=None,
         priority=None,
         status=None,
         tag=None,
@@ -233,6 +240,7 @@ class Edit(Phabfive):
 
         Args:
             task_id (str): Task ID (numeric, e.g., "123")
+            title (str): New title for the task
             priority (str): Priority to set (or "raise"/"lower")
             status (str): Status to set
             tag (str): Board name for column context
@@ -322,6 +330,7 @@ class Edit(Phabfive):
             # Delegate to maniphest module
             result = self.maniphest.edit_task_by_id(
                 task_id=task_id,
+                title=title,
                 priority=priority,
                 status=status,
                 board_phid=board_phid,

--- a/phabfive/edit/core.py
+++ b/phabfive/edit/core.py
@@ -306,6 +306,16 @@ class Edit(Phabfive):
 
                 final_description = description
 
+            # Handle title confirmation
+            if title is not None and not dry_run:
+                current_title = task_data["fields"].get("name", "")
+                if title != current_title:
+                    confirmed, return_code = confirm_text_change(
+                        current_title, title, force, filename="title"
+                    )
+                    if not confirmed:
+                        return return_code
+
             # Validate board/column context
             board_phid, error = validate_board_column_context(
                 task_id, task_data, column, tag, self.maniphest

--- a/phabfive/editor.py
+++ b/phabfive/editor.py
@@ -100,13 +100,14 @@ def show_diff(old_text, new_text, filename="description"):
             print(line, end="")
 
 
-def confirm_text_change(old_text, new_text, force):
+def confirm_text_change(old_text, new_text, force, filename="description"):
     """Show diff and get confirmation for text change.
 
     Args:
         old_text (str): Current text content
         new_text (str): New text content
         force (bool): Skip confirmation prompt
+        filename (str): Name to show in diff header (e.g., "title", "description")
 
     Returns:
         tuple: (confirmed: bool, return_code: int or None)
@@ -115,7 +116,7 @@ def confirm_text_change(old_text, new_text, force):
     import typer
 
     print()
-    show_diff(old_text, new_text)
+    show_diff(old_text, new_text, filename=filename)
     print()
 
     if force:

--- a/phabfive/maniphest/core.py
+++ b/phabfive/maniphest/core.py
@@ -2044,12 +2044,18 @@ class Maniphest(Phabfive):
             return {"task_id": task_id, "changes": []}
 
         if dry_run:
+            from phabfive.editor import show_diff
+
             print(f"[DRY RUN] Would apply to T{task_id}:")
             for change in changes:
                 field = change["field"]
                 old = change["old"]
                 new = change["new"]
-                if old is None:
+                if field == "Title":
+                    # Show unified diff for title
+                    print()
+                    show_diff(old, new, filename="title")
+                elif old is None:
                     print(f"  {field}: {new}")
                 else:
                     print(f"  {field}: {old} → {new}")

--- a/phabfive/maniphest/core.py
+++ b/phabfive/maniphest/core.py
@@ -1762,6 +1762,7 @@ class Maniphest(Phabfive):
     def edit_task_by_id(
         self,
         task_id,
+        title=None,
         priority=None,
         status=None,
         board_phid=None,
@@ -1778,6 +1779,8 @@ class Maniphest(Phabfive):
         ----------
         task_id : str
             Numeric task ID (e.g., "123")
+        title : str, optional
+            New title for the task
         priority : str, optional
             Priority to set or "raise"/"lower"
         status : str, optional
@@ -1808,9 +1811,21 @@ class Maniphest(Phabfive):
         current_priority_name = task_data["fields"]["priority"].get("name", "Unknown")
         current_status = task_data["fields"]["status"]["value"]
         current_status_name = task_data["fields"]["status"].get("name", current_status)
+        current_title = task_data["fields"].get("name", "")
 
         transactions = []
         changes = []  # Track human-readable changes for display
+
+        # Handle title
+        if title is not None and title != current_title:
+            transactions.append({"type": "title", "value": title})
+            changes.append(
+                {
+                    "field": "Title",
+                    "old": current_title,
+                    "new": title,
+                }
+            )
 
         # Handle priority
         if priority:


### PR DESCRIPTION
## Summary

- Add optional positional title argument to `maniphest edit` and `paste edit` commands for quick renaming
- Show unified diff and confirmation prompt when changing titles (matching description change UX)
- Hidden `--title` option remains available for backward compatibility

### Usage

```bash
# Quick rename with positional title
phabfive maniphest edit T123 "New Title"
phabfive paste edit P1 "New Title"

# Shows diff and prompts for confirmation:
# --- a/title
# +++ b/title
# @@ -1 +1 @@
# -Old Title
# +New Title
#
# Apply changes? [y/N]:
```

### Modes

- **Interactive**: Shows diff, prompts "Apply changes?"
- **--force**: Shows diff, no prompt
- **--dry-run**: Shows diff with "[DRY RUN]" prefix, no changes applied

## Test plan

- [x] `phabfive maniphest edit --help` shows `[TITLE]` argument
- [x] `phabfive paste edit --help` shows `[TITLE]` argument
- [x] All tests pass (`uv run pytest tests/ -x`)
- [x] Ruff checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)