### PR TITLE
feat(cli): Add hidden --title option to create commands

### DIFF
--- a/phabfive/cli/maniphest.py
+++ b/phabfive/cli/maniphest.py
@@ -157,6 +157,12 @@ def create(
     title: Optional[str] = typer.Argument(
         None, help="Task title (required unless using --with)"
     ),
+    title_opt: Optional[str] = typer.Option(
+        None,
+        "--title",
+        hidden=True,
+        help="Task title (hidden, use positional argument instead)",
+    ),
     with_template: Optional[str] = typer.Option(
         None, "--with", help="Load task creation template from YAML file"
     ),
@@ -220,6 +226,9 @@ def create(
     """
     maniphest = _get_maniphest_app()
 
+    # Merge positional and option title (positional takes precedence)
+    final_title = title or title_opt
+
     if with_template:
         # Template mode
         result = maniphest.create_tasks_from_yaml(with_template, dry_run=dry_run)
@@ -227,7 +236,7 @@ def create(
             for task in result["tasks"]:
                 indent = "  " * task["depth"]
                 typer.echo(f"{indent}- {task['title']}")
-    elif title:
+    elif final_title:
         # CLI mode - handle description input modes
         final_description = description
 
@@ -269,7 +278,7 @@ def create(
                 raise typer.Exit(1)
 
         result = maniphest.create_task(
-            title=title,
+            title=final_title,
             description=final_description,
             tags=tag,
             assignee=assign,

--- a/phabfive/cli/paste.py
+++ b/phabfive/cli/paste.py
@@ -132,9 +132,15 @@ def search(
 @paste_app.command()
 def create(
     ctx: typer.Context,
-    title: str = typer.Argument(..., help="Title for Paste"),
+    title: Optional[str] = typer.Argument(None, help="Title for Paste"),
     file: Optional[str] = typer.Argument(
         None, help="File with content (optional if using --content or $EDITOR)"
+    ),
+    title_opt: Optional[str] = typer.Option(
+        None,
+        "--title",
+        hidden=True,
+        help="Title for Paste (hidden, use positional argument instead)",
     ),
     content: Optional[str] = typer.Option(
         None,
@@ -166,6 +172,12 @@ def create(
         phabfive paste create "Notes" --subscribe=@me --tag=project
     """
     paste = _get_paste_app()
+
+    # Merge positional and option title (positional takes precedence)
+    final_title = title or title_opt
+    if not final_title:
+        sys.stderr.write("Error: Title is required\n")
+        raise typer.Exit(1)
 
     # Determine content source
     final_content = None
@@ -252,7 +264,7 @@ def create(
 
     if dry_run:
         print("[DRY RUN] Would create paste:")
-        print(f"  Title: {title}")
+        print(f"  Title: {final_title}")
         if language:
             print(f"  Language: {language}")
         if tag_list:
@@ -271,7 +283,7 @@ def create(
 
     # Create the paste
     result = paste.create_paste_from_content(
-        title=title,
+        title=final_title,
         content=final_content,
         language=language,
         tags=tag_list,


### PR DESCRIPTION
## Summary

Add hidden `--title` option to `maniphest create` and `paste create` for consistency with edit commands. This enables scripting with explicit options while keeping help output clean.

### Usage

```bash
# Now works (hidden option)
phabfive maniphest create --title="Task" --description="Lorem ipsum"
phabfive paste create --title="Paste" --content="Hello world"

# Still works (positional argument, shown in help)
phabfive maniphest create "Task" --description="Lorem ipsum"
phabfive paste create "Paste" --content="Hello world"
```

## Test plan

- [x] `--title` option works for maniphest create
- [x] `--title` option works for paste create
- [x] `--title` is hidden from `--help` output
- [x] Positional title still works
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)