### PR TITLE
feat(passphrase): Modernize passphrase app with search and package structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,15 +64,16 @@ CI will fail if files are not properly formatted.
 
 ### Feature Modules
 Complex features use a consistent subpackage structure:
-- `diffusion/` and `maniphest/` follow this pattern:
+- `diffusion/`, `maniphest/`, and `passphrase/` follow this pattern:
   - `core.py` - main class inheriting from `Phabfive`
-  - `fetchers.py` - API data fetching
-  - `resolvers.py` - ID/name resolution
-  - `formatters.py` - output formatting
-  - `validators.py` - input validation
+  - `display.py` - output formatting (passphrase)
+  - `fetchers.py` - API data fetching (diffusion, maniphest)
+  - `resolvers.py` - ID/name resolution (diffusion, maniphest)
+  - `formatters.py` - output formatting (diffusion, maniphest)
+  - `validators.py` - input validation (diffusion, maniphest)
 
 ### Simpler Modules
-- `passphrase.py`, `paste.py`, `user.py` - single-file implementations
+- `paste.py`, `user.py` - single-file implementations
 - `transitions/` - state machine for task status/priority/column changes
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CLI for [Phabricator](https://www.phacility.com/phabricator/) and [Phorge](https
 - **Maniphest** - Full task management: create, show, edit, search, comment, parents/subtasks
 - **Paste** - Create, show, edit, search, and comment on pastes
 - **Diffusion** - Repository management, branches, and URI configuration
-- **Passphrase** - Retrieve secrets securely
+- **Passphrase** - Search, list, and retrieve secrets (passwords, tokens, SSH keys, notes)
 - **User** - User info and interactive setup wizard
 
 Cross-cutting features:

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,9 +32,8 @@ uv tool install phabfive
 phabfive K123
 
 # Search and filter credentials
-phabfive passphrase search
-phabfive passphrase search --type=password
 phabfive passphrase search "deploy"
+phabfive passphrase search --type=password
 
 # Show multiple secrets at once
 phabfive passphrase show K1 K2 K3

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ Phabfive is a command line tool to interact with Phabricator/Phorge, providing a
 
 Phabfive currently supports the following Phabricator/Phorge applications:
 
-- **Passphrase** - Get specified secrets for credential management
+- **Passphrase** - Search, list, and retrieve secrets (passwords, tokens, SSH keys, notes)
 - **Diffusion** - List repositories, get branches, clone URIs, add repositories, manage URIs
 - **Paste** - List, get, and add code pastes
 - **User** - Get information about the logged-in user
@@ -28,8 +28,16 @@ uv tool install phabfive
 ### Basic Usage
 
 ```bash
-# Get a secret from Passphrase
-phabfive passphrase K123
+# Get a secret from Passphrase (monogram shortcut)
+phabfive K123
+
+# Search and filter credentials
+phabfive passphrase search
+phabfive passphrase search --type=password
+phabfive passphrase search "deploy"
+
+# Show multiple secrets at once
+phabfive passphrase show K1 K2 K3
 
 # List pastes
 phabfive paste list

--- a/phabfive/cli/passphrase.py
+++ b/phabfive/cli/passphrase.py
@@ -2,10 +2,15 @@
 """Passphrase commands for phabfive CLI."""
 
 import sys
+from typing import List, Optional
 
 import typer
 
-from phabfive.exceptions import PhabfiveConfigException, PhabfiveDataException
+from phabfive.exceptions import (
+    PhabfiveConfigException,
+    PhabfiveDataException,
+    PhabfiveRemoteException,
+)
 
 passphrase_app = typer.Typer(help="The passphrase app")
 
@@ -30,22 +35,130 @@ def _get_passphrase_app():
         raise typer.Exit(1)
 
 
+def _get_output_format(ctx: typer.Context):
+    """Get output format from context."""
+    from phabfive.core import Phabfive
+
+    format_arg = ctx.obj.get("format") if ctx.obj else None
+    return format_arg if format_arg else Phabfive._get_auto_format()
+
+
 @passphrase_app.command()
 def show(
     ctx: typer.Context,
-    id: str = typer.Argument(..., help="Passphrase ID (e.g., K123)"),
+    ids: List[str] = typer.Argument(
+        ..., help="Passphrase ID(s) (e.g., K1 K2 or K1,K2,K3)"
+    ),
+    no_secret: bool = typer.Option(
+        False, "--no-secret", "-n", help="Hide the secret value"
+    ),
+    no_public_key: bool = typer.Option(
+        False, "--no-public-key", "-P", help="Hide public key for SSH credentials"
+    ),
 ) -> None:
-    """Retrieve a secret from Passphrase by ID."""
-    from phabfive.core import Phabfive
-    from phabfive.passphrase_display import display_passphrase
+    """Retrieve secrets from Passphrase by ID.
+
+    Examples:
+        phabfive passphrase show K1
+        phabfive passphrase show K1 K2 K3
+        phabfive passphrase show K1,K2,K3
+        phabfive K1  # shortcut
+        phabfive K1,K2  # shortcut for multiple
+    """
+    from phabfive.passphrase_display import display_passphrases
 
     passphrase = _get_passphrase_app()
-    try:
-        data = passphrase.get_passphrase(id)
 
-        format_arg = ctx.obj.get("format") if ctx.obj else None
-        output_format = format_arg if format_arg else Phabfive._get_auto_format()
-        display_passphrase(data, output_format, passphrase)
-    except PhabfiveDataException as e:
+    # Support both space-separated (K1 K2) and comma-separated (K1,K2,K3)
+    all_ids = []
+    for id_arg in ids:
+        all_ids.extend(part.strip() for part in id_arg.split(",") if part.strip())
+
+    try:
+        output_format = _get_output_format(ctx)
+        need_secrets = not no_secret
+        need_public_keys = not no_public_key
+
+        # Always use get_passphrases for consistent behavior
+        data = passphrase.get_passphrases(
+            all_ids,
+            need_secrets=need_secrets,
+            need_public_keys=need_public_keys,
+        )
+
+        if len(all_ids) == 1:
+            # Single credential - use singular display
+            from phabfive.passphrase_display import display_passphrase
+
+            display_passphrase(data[0], output_format, passphrase)
+        else:
+            # Multiple credentials
+            display_passphrases(
+                data, output_format, passphrase, show_secrets=need_secrets
+            )
+
+    except (PhabfiveDataException, PhabfiveRemoteException) as e:
+        typer.echo(f"ERROR: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@passphrase_app.command()
+def search(
+    ctx: typer.Context,
+    query: Optional[str] = typer.Argument(None, help="Search by name (partial match)"),
+    credential_type: Optional[str] = typer.Option(
+        None,
+        "--type",
+        "-t",
+        help="Filter by type: password, token, key, note",
+    ),
+    show_secret: bool = typer.Option(
+        False,
+        "--show-secret",
+        "-s",
+        help="Include secrets in output (hidden by default)",
+    ),
+    limit: int = typer.Option(
+        100,
+        "--limit",
+        "-l",
+        help="Maximum results to return",
+    ),
+) -> None:
+    """List and search credentials.
+
+    Examples:
+        phabfive passphrase search
+        phabfive passphrase search "deploy"
+        phabfive passphrase search --type=password
+        phabfive passphrase search --show-secret
+        phabfive --format=json passphrase search
+    """
+    from phabfive.passphrase_display import display_passphrases_list
+
+    passphrase = _get_passphrase_app()
+
+    try:
+        credentials = passphrase.search_passphrases(
+            query=query,
+            credential_type=credential_type,
+            need_secrets=show_secret,
+            limit=limit,
+        )
+
+        output_format = _get_output_format(ctx)
+
+        if not credentials:
+            if query or credential_type:
+                typer.echo("No credentials found matching the criteria", err=True)
+            else:
+                typer.echo("No credentials found", err=True)
+            raise typer.Exit(0)
+
+        display_passphrases_list(
+            credentials, output_format, passphrase, show_secrets=show_secret
+        )
+
+    except (PhabfiveDataException, PhabfiveRemoteException) as e:
         typer.echo(f"ERROR: {e}", err=True)
         raise typer.Exit(1)

--- a/phabfive/cli/passphrase.py
+++ b/phabfive/cli/passphrase.py
@@ -65,7 +65,7 @@ def show(
         phabfive K1  # shortcut
         phabfive K1,K2  # shortcut for multiple
     """
-    from phabfive.passphrase_display import display_passphrases
+    from phabfive.passphrase.display import display_passphrases
 
     passphrase = _get_passphrase_app()
 
@@ -88,7 +88,7 @@ def show(
 
         if len(all_ids) == 1:
             # Single credential - use singular display
-            from phabfive.passphrase_display import display_passphrase
+            from phabfive.passphrase.display import display_passphrase
 
             display_passphrase(data[0], output_format, passphrase)
         else:
@@ -134,7 +134,7 @@ def search(
         phabfive passphrase search --show-secret
         phabfive --format=json passphrase search
     """
-    from phabfive.passphrase_display import display_passphrases_list
+    from phabfive.passphrase.display import display_passphrases_list
 
     passphrase = _get_passphrase_app()
 

--- a/phabfive/cli/passphrase.py
+++ b/phabfive/cli/passphrase.py
@@ -105,7 +105,9 @@ def show(
 @passphrase_app.command()
 def search(
     ctx: typer.Context,
-    query: Optional[str] = typer.Argument(None, help="Search by name (partial match)"),
+    text_query: Optional[str] = typer.Argument(
+        None, help="Search by name (partial match)"
+    ),
     credential_type: Optional[str] = typer.Option(
         None,
         "--type",
@@ -125,23 +127,28 @@ def search(
         help="Maximum results to return",
     ),
 ) -> None:
-    """List and search credentials.
+    """Search credentials by name or type.
 
     \b
     Examples:
-        phabfive passphrase search
         phabfive passphrase search "deploy"
         phabfive passphrase search --type=password
-        phabfive passphrase search --show-secret
-        phabfive --format=json passphrase search
+        phabfive passphrase search "api" --type=token
+        phabfive --format=json passphrase search --type=key
     """
     from phabfive.passphrase.display import display_passphrases_list
+
+    # Require at least one search criterion
+    if not text_query and not credential_type:
+        typer.echo("Usage:")
+        typer.echo("    phabfive passphrase search [<text_query>] [options]")
+        return
 
     passphrase = _get_passphrase_app()
 
     try:
         credentials = passphrase.search_passphrases(
-            query=query,
+            query=text_query,
             credential_type=credential_type,
             need_secrets=show_secret,
             limit=limit,
@@ -150,7 +157,7 @@ def search(
         output_format = _get_output_format(ctx)
 
         if not credentials:
-            if query or credential_type:
+            if text_query or credential_type:
                 typer.echo("No credentials found matching the criteria", err=True)
             else:
                 typer.echo("No credentials found", err=True)

--- a/phabfive/cli/passphrase.py
+++ b/phabfive/cli/passphrase.py
@@ -58,12 +58,12 @@ def show(
 ) -> None:
     """Retrieve secrets from Passphrase by ID.
 
+    \b
     Examples:
         phabfive passphrase show K1
         phabfive passphrase show K1 K2 K3
         phabfive passphrase show K1,K2,K3
         phabfive K1  # shortcut
-        phabfive K1,K2  # shortcut for multiple
     """
     from phabfive.passphrase.display import display_passphrases
 
@@ -127,6 +127,7 @@ def search(
 ) -> None:
     """List and search credentials.
 
+    \b
     Examples:
         phabfive passphrase search
         phabfive passphrase search "deploy"

--- a/phabfive/passphrase.py
+++ b/phabfive/passphrase.py
@@ -135,3 +135,200 @@ class Passphrase(Phabfive):
         """
         data = self.get_passphrase(ids)
         return data["secret"]
+
+    def _format_credential(self, data, need_secrets=True, need_public_keys=False):
+        """Format a single credential from API response.
+
+        Parameters
+        ----------
+        data : dict
+            Raw credential data from API
+        need_secrets : bool
+            Whether to include secret material
+        need_public_keys : bool
+            Whether to include public keys for SSH credentials
+
+        Returns
+        -------
+        dict
+            Formatted credential data
+        """
+        # Map API type to display type
+        type_map = {
+            "password": "Password",
+            "token": "Token",
+            "ssh-generated-key": "SSH Key",
+            "ssh-key-text": "SSH Key",
+            "note": "Note",
+        }
+
+        material = data.get("material", {})
+        if isinstance(material, list):
+            material = {}
+
+        # Extract secret from material (different key per type)
+        secret = None
+        if need_secrets:
+            if "noAPIAccess" in material:
+                secret = "[Access denied - enable Conduit access in web UI]"
+            else:
+                secret = (
+                    material.get("password")  # nosec-B105
+                    or material.get("token")
+                    or material.get("privateKey")
+                    or material.get("note")
+                    or ""
+                )
+
+        # Extract public key for SSH credentials
+        public_key = None
+        if need_public_keys and data.get("type") in (
+            "ssh-generated-key",
+            "ssh-key-text",
+        ):
+            public_key = material.get("publicKey")
+
+        monogram = f"K{data['id']}"
+        url = f"{self.url}/{monogram}"
+        credential_type = data.get("type", "")
+
+        result = {
+            "id": monogram,
+            "url": url,
+            "_link": self.format_link(url, monogram),
+            "type": type_map.get(credential_type, credential_type or "Unknown"),
+            "name": data.get("name", ""),
+            "username": data.get("username"),
+        }
+
+        if need_secrets:
+            result["secret"] = secret
+
+        if need_public_keys and public_key:
+            result["public_key"] = public_key
+
+        return result
+
+    def search_passphrases(
+        self, query=None, credential_type=None, need_secrets=False, limit=100
+    ):
+        """Search/list all accessible credentials.
+
+        Parameters
+        ----------
+        query : str, optional
+            Filter by name (case-insensitive partial match)
+        credential_type : str, optional
+            Filter by type: password, token, key, note
+        need_secrets : bool
+            Include secret material (default: False for security)
+        limit : int
+            Maximum number of results
+
+        Returns
+        -------
+        list
+            List of credential dictionaries
+        """
+        try:
+            response = self.phab.passphrase.query(
+                needSecrets=1 if need_secrets else 0,
+                limit=limit,
+            )
+        except APIError as e:
+            raise PhabfiveRemoteException(e)
+
+        credentials = []
+        data = response.get("data", {})
+
+        # Map user-friendly type names to API types
+        type_filter_map = {
+            "password": ["password"],
+            "token": ["token"],
+            "key": ["ssh-generated-key", "ssh-key-text"],
+            "ssh": ["ssh-generated-key", "ssh-key-text"],
+            "note": ["note"],
+        }
+
+        for item in data.values():
+            # Apply type filter
+            if credential_type:
+                api_types = type_filter_map.get(credential_type.lower(), [])
+                if api_types and item.get("type") not in api_types:
+                    continue
+
+            # Apply name filter (case-insensitive partial match)
+            if query:
+                name = item.get("name", "")
+                if query.lower() not in name.lower():
+                    continue
+
+            credentials.append(self._format_credential(item, need_secrets=need_secrets))
+
+        return credentials
+
+    def get_passphrases(self, id_list, need_secrets=True, need_public_keys=False):
+        """Retrieve multiple passphrases by ID.
+
+        Parameters
+        ----------
+        id_list : list
+            List of passphrase IDs (e.g., ["K1", "K2", "K3"])
+        need_secrets : bool
+            Include secret material
+        need_public_keys : bool
+            Include public keys for SSH credentials
+
+        Returns
+        -------
+        list
+            List of credential dictionaries
+
+        Raises
+        ------
+        PhabfiveDataException
+            If any ID is invalid or not found
+        """
+        # Validate all IDs first
+        numeric_ids = []
+        for id_str in id_list:
+            id_str = id_str.strip()
+            if not self._validate_identifier(id_str):
+                raise PhabfiveDataException(
+                    f"Invalid passphrase ID '{id_str}'. Expected format: K123"
+                )
+            numeric_ids.append(id_str.replace("K", ""))
+
+        try:
+            response = self.phab.passphrase.query(
+                ids=numeric_ids,
+                needSecrets=1 if need_secrets else 0,
+                needPublicKeys=1 if need_public_keys else 0,
+            )
+        except APIError as e:
+            raise PhabfiveRemoteException(e)
+
+        data = response.get("data", {})
+
+        if not data:
+            raise PhabfiveDataException("No credentials found for the specified IDs")
+
+        credentials = []
+        # Preserve order of requested IDs
+        for numeric_id in numeric_ids:
+            found = False
+            for item in data.values():
+                if str(item.get("id")) == numeric_id:
+                    credentials.append(
+                        self._format_credential(
+                            item,
+                            need_secrets=need_secrets,
+                            need_public_keys=need_public_keys,
+                        )
+                    )
+                    found = True
+                    break
+            if not found:
+                raise PhabfiveDataException(f"K{numeric_id} not found or access denied")
+
+        return credentials

--- a/phabfive/passphrase/__init__.py
+++ b/phabfive/passphrase/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Passphrase package for credential management."""
+
+from phabfive.passphrase.core import Passphrase
+
+__all__ = ["Passphrase"]

--- a/phabfive/passphrase/core.py
+++ b/phabfive/passphrase/core.py
@@ -1,18 +1,15 @@
 # -*- coding: utf-8 -*-
+"""Core Passphrase class for credential management."""
 
-# python std lib
 import json
 import logging
 import re
 
-# phabfive imports
+from phabricator import APIError
+
 from phabfive.constants import MONOGRAMS
 from phabfive.core import Phabfive
 from phabfive.exceptions import PhabfiveDataException, PhabfiveRemoteException
-
-# 3rd party imports
-from phabricator import APIError
-
 
 log = logging.getLogger(__name__)
 

--- a/phabfive/passphrase/display.py
+++ b/phabfive/passphrase/display.py
@@ -191,7 +191,7 @@ def display_passphrase_json(passphrase_dict):
     if public_key:
         output["PublicKey"] = public_key
 
-    print(json.dumps(output, indent=2))
+    print(json.dumps(output, indent=2))  # noqa: T201  # lgtm[py/clear-text-logging-sensitive-data]
 
 
 def display_passphrase_simple(passphrase_dict):
@@ -202,7 +202,8 @@ def display_passphrase_simple(passphrase_dict):
     passphrase_dict : dict
         Passphrase data dictionary with secret
     """
-    print(passphrase_dict.get("secret", ""))
+    # Intentional: This function's purpose is to output secrets for piping
+    print(passphrase_dict.get("secret", ""))  # noqa: T201  # lgtm[py/clear-text-logging-sensitive-data]
 
 
 def display_passphrase(passphrase_dict, output_format, phabfive_instance):
@@ -258,7 +259,8 @@ def display_passphrases(
         if output_format == "simple":
             for cred in credentials:
                 if show_secrets and "secret" in cred:
-                    print(cred.get("secret", ""))
+                    # Intentional: Output secrets for piping
+                    print(cred.get("secret", ""))  # noqa: T201  # lgtm[py/clear-text-logging-sensitive-data]
         elif output_format == "tree":
             for cred in credentials:
                 display_passphrase_tree(console, cred, phabfive_instance)

--- a/phabfive/passphrase/display.py
+++ b/phabfive/passphrase/display.py
@@ -353,26 +353,6 @@ def display_passphrases_json(credentials, show_secrets=True):
     print(json.dumps(output, indent=2))
 
 
-def display_passphrases_list_compact(credentials):
-    """Display credentials as a compact list (search results).
-
-    Uses same field naming as passphrase show (capitalized).
-
-    Parameters
-    ----------
-    credentials : list
-        List of credential dictionaries (without secrets)
-    """
-    for cred in credentials:
-        url = cred.get("url", cred.get("id", ""))
-        cred_type = cred.get("type", "Unknown")
-        name = cred.get("name", "")
-
-        print(f"- Link: {url}")
-        print(f"  Type: {cred_type}")
-        print(f"  Name: {name}")
-
-
 def display_passphrases_list(
     credentials, output_format, phabfive_instance, show_secrets=False
 ):

--- a/phabfive/passphrase_display.py
+++ b/phabfive/passphrase_display.py
@@ -42,13 +42,24 @@ def display_passphrase_rich(console, passphrase_dict, phabfive_instance):
     if username:
         console.print(f"  Username: {username}")
 
-    # Print Secret (handle multi-line for SSH keys)
-    if "\n" in secret:
-        console.print("  Secret: |-")
-        for line in secret.splitlines():
-            console.print(f"    {line}")
-    else:
-        console.print(f"  Secret: {secret}")
+    # Print Secret (only when present and non-empty)
+    if "secret" in passphrase_dict and secret:
+        if "\n" in secret:
+            console.print("  Secret: |-")
+            for line in secret.splitlines():
+                console.print(f"    {line}")
+        else:
+            console.print(f"  Secret: {secret}")
+
+    # Print Public Key (only for SSH credentials when requested)
+    public_key = passphrase_dict.get("public_key", "")
+    if public_key:
+        if "\n" in public_key:
+            console.print("  PublicKey: |-")
+            for line in public_key.splitlines():
+                console.print(f"    {line}")
+        else:
+            console.print(f"  PublicKey: {public_key}")
 
 
 def display_passphrase_tree(console, passphrase_dict, phabfive_instance):
@@ -79,14 +90,28 @@ def display_passphrase_tree(console, passphrase_dict, phabfive_instance):
     if username:
         tree.add(f"Username: {username}")
 
-    # For multi-line secrets, show first line only
-    if "\n" in secret:
-        first_line = secret.split("\n")[0]
-        if len(first_line) > 50:
-            first_line = first_line[:47] + "..."
-        tree.add(f"Secret: {first_line}")
-    else:
-        tree.add(f"Secret: {secret}")
+    # Show secret only if present and non-empty
+    if "secret" in passphrase_dict and secret:
+        secret_stripped = secret.strip()
+        # For multi-line secrets, use subtree
+        if "\n" in secret_stripped:
+            secret_branch = tree.add("Secret:")
+            for line in secret_stripped.splitlines():
+                secret_branch.add(line)
+        else:
+            tree.add(f"Secret: {secret_stripped}")
+
+    # Show public key if present
+    public_key = passphrase_dict.get("public_key", "")
+    if public_key:
+        public_key_stripped = public_key.strip()
+        # For multi-line, use subtree; otherwise show full
+        if "\n" in public_key_stripped:
+            pk_branch = tree.add("PublicKey:")
+            for line in public_key_stripped.splitlines():
+                pk_branch.add(line)
+        else:
+            tree.add(f"PublicKey: {public_key_stripped}")
 
     console.print(tree)
 
@@ -124,6 +149,14 @@ def display_passphrase_yaml(passphrase_dict):
     else:
         output["Secret"] = secret
 
+    # Include PublicKey for SSH credentials
+    public_key = passphrase_dict.get("public_key", "")
+    if public_key:
+        if "\n" in public_key:
+            output["PublicKey"] = PreservedScalarString(public_key)
+        else:
+            output["PublicKey"] = public_key
+
     stream = StringIO()
     yaml.dump([output], stream)
     print(stream.getvalue(), end="")
@@ -152,6 +185,11 @@ def display_passphrase_json(passphrase_dict):
         output["Username"] = username
 
     output["Secret"] = passphrase_dict.get("secret", "")
+
+    # Include PublicKey for SSH credentials
+    public_key = passphrase_dict.get("public_key")
+    if public_key:
+        output["PublicKey"] = public_key
 
     print(json.dumps(output, indent=2))
 
@@ -194,5 +232,181 @@ def display_passphrase(passphrase_dict, output_format, phabfive_instance):
             display_passphrase_rich(console, passphrase_dict, phabfive_instance)
     except BrokenPipeError:
         # Handle pipe closed by consumer (e.g., head, less)
+        sys.stderr.close()
+        sys.exit(0)
+
+
+def display_passphrases(
+    credentials, output_format, phabfive_instance, show_secrets=True
+):
+    """Display multiple passphrases in the specified format.
+
+    Parameters
+    ----------
+    credentials : list
+        List of passphrase data dictionaries
+    output_format : str
+        One of 'rich', 'tree', 'yaml', 'json', or 'simple'
+    phabfive_instance : Phabfive
+        Instance to access formatting helpers
+    show_secrets : bool
+        Whether to show secret values
+    """
+    console = phabfive_instance.get_console()
+
+    try:
+        if output_format == "simple":
+            for cred in credentials:
+                if show_secrets and "secret" in cred:
+                    print(cred.get("secret", ""))
+        elif output_format == "tree":
+            for cred in credentials:
+                display_passphrase_tree(console, cred, phabfive_instance)
+        elif output_format in ("yaml", "strict"):
+            display_passphrases_yaml(credentials, show_secrets)
+        elif output_format == "json":
+            display_passphrases_json(credentials, show_secrets)
+        else:  # "rich" (default)
+            for cred in credentials:
+                display_passphrase_rich(console, cred, phabfive_instance)
+    except BrokenPipeError:
+        sys.stderr.close()
+        sys.exit(0)
+
+
+def display_passphrases_yaml(credentials, show_secrets=True):
+    """Display multiple passphrases as YAML.
+
+    Parameters
+    ----------
+    credentials : list
+        List of passphrase data dictionaries
+    show_secrets : bool
+        Whether to include secret values
+    """
+    yaml = YAML()
+    yaml.default_flow_style = False
+
+    output = []
+    for cred in credentials:
+        item = {
+            "Link": cred.get("url", ""),
+            "Type": cred.get("type", "Unknown"),
+            "Name": cred.get("name", ""),
+        }
+
+        username = cred.get("username")
+        if username:
+            item["Username"] = username
+
+        if show_secrets and "secret" in cred:
+            secret = cred.get("secret", "")
+            if "\n" in secret:
+                item["Secret"] = PreservedScalarString(secret)
+            else:
+                item["Secret"] = secret
+
+        if "public_key" in cred:
+            public_key = cred.get("public_key", "")
+            if "\n" in public_key:
+                item["PublicKey"] = PreservedScalarString(public_key)
+            else:
+                item["PublicKey"] = public_key
+
+        output.append(item)
+
+    stream = StringIO()
+    yaml.dump(output, stream)
+    print(stream.getvalue(), end="")
+
+
+def display_passphrases_json(credentials, show_secrets=True):
+    """Display multiple passphrases as JSON.
+
+    Parameters
+    ----------
+    credentials : list
+        List of passphrase data dictionaries
+    show_secrets : bool
+        Whether to include secret values
+    """
+    output = []
+    for cred in credentials:
+        item = {
+            "Link": cred.get("url", ""),
+            "Type": cred.get("type", "Unknown"),
+            "Name": cred.get("name", ""),
+        }
+
+        username = cred.get("username")
+        if username:
+            item["Username"] = username
+
+        if show_secrets and "secret" in cred:
+            item["Secret"] = cred.get("secret", "")
+
+        if "public_key" in cred:
+            item["PublicKey"] = cred.get("public_key", "")
+
+        output.append(item)
+
+    print(json.dumps(output, indent=2))
+
+
+def display_passphrases_list_compact(credentials):
+    """Display credentials as a compact list (search results).
+
+    Uses same field naming as passphrase show (capitalized).
+
+    Parameters
+    ----------
+    credentials : list
+        List of credential dictionaries (without secrets)
+    """
+    for cred in credentials:
+        url = cred.get("url", cred.get("id", ""))
+        cred_type = cred.get("type", "Unknown")
+        name = cred.get("name", "")
+
+        print(f"- Link: {url}")
+        print(f"  Type: {cred_type}")
+        print(f"  Name: {name}")
+
+
+def display_passphrases_list(
+    credentials, output_format, phabfive_instance, show_secrets=False
+):
+    """Display credentials list in the specified format (for search).
+
+    Parameters
+    ----------
+    credentials : list
+        List of credential dictionaries
+    output_format : str
+        One of 'rich', 'tree', 'yaml', 'json', 'simple'
+    phabfive_instance : Phabfive
+        Instance to access formatting helpers
+    show_secrets : bool
+        Whether to show secret values (default: False for search)
+    """
+    console = phabfive_instance.get_console()
+
+    try:
+        if output_format == "json":
+            display_passphrases_json(credentials, show_secrets)
+        elif output_format in ("yaml", "strict"):
+            display_passphrases_yaml(credentials, show_secrets)
+        elif output_format == "tree":
+            for cred in credentials:
+                display_passphrase_tree(console, cred, phabfive_instance)
+        elif output_format == "simple":
+            # Just output monograms for simple format
+            for cred in credentials:
+                print(cred.get("id", ""))
+        else:
+            # rich format (default) - YAML-like with Rich console
+            for cred in credentials:
+                display_passphrase_rich(console, cred, phabfive_instance)
+    except BrokenPipeError:
         sys.stderr.close()
         sys.exit(0)


### PR DESCRIPTION
## Summary

- Add `search` command to filter credentials by name or type
- Enhance `show` command with multiple IDs support (space or comma-separated)
- Add `--no-secret/-n` to hide secrets, `--no-public-key/-P` to hide SSH public keys
- Public keys shown by default for SSH credentials
- All output formats supported (rich, tree, yaml, json, simple)
- Refactor passphrase module into package structure (passphrase/core.py, passphrase/display.py)

### New Commands

| Command | Description |
|---------|-------------|
| `phabfive passphrase search "deploy"` | Search by name |
| `phabfive passphrase search --type=password` | Filter by type |
| `phabfive passphrase show K1 K2 K3` | Show multiple (space-separated) |
| `phabfive passphrase show K1,K2,K3` | Show multiple (comma-separated) |
| `phabfive passphrase show K1 --no-secret` | Hide secret value |

## Test plan

- [x] All existing tests pass (384 passed)
- [x] Tested search with various filters against local Phorge
- [x] Tested show with single and multiple IDs
- [x] Tested all output formats (rich, tree, yaml, json, simple)
- [x] Tested public key display for SSH credentials
- [x] Verified package imports work correctly after refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)