### PR TITLE
fix(paste): Consistent output formats and search behavior

### DIFF
--- a/phabfive/cli/paste.py
+++ b/phabfive/cli/paste.py
@@ -3,12 +3,12 @@
 
 import re
 import sys
-from datetime import datetime
 from typing import List, Optional
 
 import typer
 from io import StringIO
 
+from rich.text import Text
 from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import PreservedScalarString
 
@@ -348,98 +348,116 @@ def _display_pastes(result, output_format, paste_instance):
     """Display paste results in the specified format."""
     import json
 
-    from rich.syntax import Syntax
-
     if not result or not result.get("pastes"):
         return
 
     pastes = result["pastes"]
 
     if output_format == "json":
-        print(json.dumps(pastes, indent=2, default=str))
+        # Use capitalized keys like passphrase/maniphest
+        output = []
+        for p in pastes:
+            item = {
+                "Link": p.get("url", ""),
+                "Title": p.get("title", ""),
+                "Author": p.get("author", ""),
+                "Language": p.get("language", "text"),
+                "Status": p.get("status", ""),
+            }
+            if "content" in p:
+                item["Content"] = p.get("content", "")
+            output.append(item)
+        print(json.dumps(output, indent=2, default=str))
     elif output_format in ("yaml", "strict"):
         yaml = YAML()
         yaml.default_flow_style = False
-        # Convert content to block scalar for readability
+        # Use capitalized keys like passphrase/maniphest
         output = []
         for p in pastes:
-            item = dict(p)
-            if "content" in item and "\n" in item.get("content", ""):
-                item["content"] = PreservedScalarString(item["content"])
+            item = {
+                "Link": p.get("url", ""),
+                "Title": p.get("title", ""),
+                "Author": p.get("author", ""),
+                "Language": p.get("language", "text"),
+                "Status": p.get("status", ""),
+            }
+            if "content" in p:
+                content = p.get("content", "")
+                if "\n" in content:
+                    item["Content"] = PreservedScalarString(content)
+                else:
+                    item["Content"] = content
             output.append(item)
         stream = StringIO()
         yaml.dump(output, stream)
         print(stream.getvalue(), end="")
+    elif output_format == "tree":
+        from rich.tree import Tree
+
+        console = paste_instance.get_console()
+        for paste_data in pastes:
+            # Use URL as tree root (like passphrase/maniphest)
+            tree = Tree(paste_data.get("url", paste_data["id"]))
+            tree.add(f"Title: {paste_data.get('title', '')}")
+            if paste_data.get("author"):
+                tree.add(f"Author: {paste_data['author']}")
+            if paste_data.get("language"):
+                tree.add(f"Language: {paste_data['language']}")
+            if paste_data.get("status"):
+                tree.add(f"Status: {paste_data['status']}")
+            if paste_data.get("content"):
+                # Show content preview for tree view
+                content = paste_data["content"]
+                if "\n" in content:
+                    content_branch = tree.add("Content:")
+                    for line in content.splitlines()[:5]:
+                        content_branch.add(line)
+                    if len(content.splitlines()) > 5:
+                        content_branch.add("...")
+                else:
+                    tree.add(
+                        f"Content: {content[:100]}{'...' if len(content) > 100 else ''}"
+                    )
+            console.print(tree)
+    elif output_format == "simple":
+        # Just output content for piping (like passphrase outputs secret)
+        for paste_data in pastes:
+            if paste_data.get("content"):
+                print(paste_data["content"])
     else:
-        # Rich format
+        # Rich format - YAML-like output with hyperlinks
         console = paste_instance.get_console()
 
         for paste_data in pastes:
-            # Build header
-            title = f"{paste_data['id']}: {paste_data['title']}"
+            link = paste_data.get("_link")
 
-            # Build metadata lines
-            lines = []
+            # Print link
+            console.print(Text.assemble("- Link: ", link))
+
+            # Print Title
+            console.print(f"  Title: {paste_data.get('title', '')}")
+
+            # Print Author (only when present)
             if paste_data.get("author"):
-                lines.append(f"Author: {paste_data['author']}")
+                console.print(f"  Author: {paste_data['author']}")
+
+            # Print Language
             if paste_data.get("language"):
-                lines.append(f"Language: {paste_data['language']}")
-            if paste_data.get("dateCreated"):
-                created = datetime.fromtimestamp(paste_data["dateCreated"])
-                lines.append(f"Created: {created.strftime('%Y-%m-%d %H:%M')}")
+                console.print(f"  Language: {paste_data['language']}")
 
-            # Print header and metadata
-            console.print(f"[bold]{title}[/bold]")
-            console.print("─" * min(len(title) + 10, 60))
-            for line in lines:
-                console.print(line)
+            # Print Status
+            if paste_data.get("status"):
+                console.print(f"  Status: {paste_data['status']}")
 
-            # Print content with syntax highlighting
-            if paste_data.get("content"):
-                console.print()
-                language = paste_data.get("language", "text")
-                # Map common phabricator language names to pygments lexers
-                lang_map = {
-                    "text": "text",
-                    "python": "python",
-                    "python3": "python",
-                    "javascript": "javascript",
-                    "js": "javascript",
-                    "bash": "bash",
-                    "shell": "bash",
-                    "json": "json",
-                    "yaml": "yaml",
-                    "sql": "sql",
-                    "html": "html",
-                    "css": "css",
-                    "c": "c",
-                    "cpp": "cpp",
-                    "java": "java",
-                    "go": "go",
-                    "rust": "rust",
-                    "ruby": "ruby",
-                    "php": "php",
-                }
-                lexer = lang_map.get(language.lower(), "text")
-                try:
-                    # Use word_wrap to prevent extremely wide output
-                    syntax = Syntax(
-                        paste_data["content"],
-                        lexer,
-                        theme="monokai",
-                        line_numbers=True,
-                        word_wrap=True,
-                    )
-                    # Print syntax with auto width (not the large MAX_LINE_WIDTH)
-                    from rich.console import Console as SyntaxConsole
-
-                    syntax_console = SyntaxConsole()
-                    syntax_console.print(syntax)
-                except Exception:
-                    # Fall back to plain text if syntax highlighting fails
-                    console.print(paste_data["content"])
-
-            console.print()
+            # Print Content (only when present and non-empty)
+            content = paste_data.get("content", "")
+            if content:
+                if "\n" in content:
+                    console.print("  Content: |-")
+                    for line in content.splitlines():
+                        console.print(f"    {line}")
+                else:
+                    console.print(f"  Content: {content}")
 
 
 @paste_app.command()

--- a/phabfive/cli/paste.py
+++ b/phabfive/cli/paste.py
@@ -65,7 +65,9 @@ def _get_paste_app():
 @paste_app.command()
 def search(
     ctx: typer.Context,
-    query: Optional[str] = typer.Argument(None, help="Free-text search in paste title"),
+    text_query: Optional[str] = typer.Argument(
+        None, help="Free-text search in paste title"
+    ),
     author: Optional[str] = typer.Option(
         None, "--author", help="Filter by author (username or @me)"
     ),
@@ -74,12 +76,17 @@ def search(
 
     \b
     Examples:
-        phabfive paste search
         phabfive paste search "script"
         phabfive paste search --author=@me
         phabfive paste search "config" --author=@me
-        phabfive --format=yaml paste search
+        phabfive --format=yaml paste search "notes"
     """
+    # Require at least one search criterion
+    if not text_query and not author:
+        typer.echo("Usage:")
+        typer.echo("    phabfive paste search [<text_query>] [options]")
+        return
+
     _setup_output_options(ctx)
     paste = _get_paste_app()
 
@@ -87,8 +94,8 @@ def search(
     constraints = {}
 
     # Handle free-text query
-    if query:
-        constraints["query"] = query
+    if text_query:
+        constraints["query"] = text_query
 
     # Handle @me shortcut for author
     if author:

--- a/phabfive/cli/paste.py
+++ b/phabfive/cli/paste.py
@@ -7,7 +7,10 @@ from datetime import datetime
 from typing import List, Optional
 
 import typer
-import yaml
+from io import StringIO
+
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import PreservedScalarString
 
 from phabfive.cli.completers import complete_language
 from phabfive.constants import MONOGRAMS
@@ -129,7 +132,11 @@ def search(
         print(json.dumps(result, indent=2))
     elif output_format in ("yaml", "strict"):
         result = [{"id": f"P{p['id']}", "title": p["fields"]["title"]} for p in pastes]
-        print(yaml.dump(result, default_flow_style=False, allow_unicode=True))
+        yaml = YAML()
+        yaml.default_flow_style = False
+        stream = StringIO()
+        yaml.dump(result, stream)
+        print(stream.getvalue(), end="")
     else:
         # Rich/default format
         for p in pastes:
@@ -351,7 +358,18 @@ def _display_pastes(result, output_format, paste_instance):
     if output_format == "json":
         print(json.dumps(pastes, indent=2, default=str))
     elif output_format in ("yaml", "strict"):
-        print(yaml.dump(pastes, default_flow_style=False, allow_unicode=True))
+        yaml = YAML()
+        yaml.default_flow_style = False
+        # Convert content to block scalar for readability
+        output = []
+        for p in pastes:
+            item = dict(p)
+            if "content" in item and "\n" in item.get("content", ""):
+                item["content"] = PreservedScalarString(item["content"])
+            output.append(item)
+        stream = StringIO()
+        yaml.dump(output, stream)
+        print(stream.getvalue(), end="")
     else:
         # Rich format
         console = paste_instance.get_console()
@@ -404,13 +422,19 @@ def _display_pastes(result, output_format, paste_instance):
                 }
                 lexer = lang_map.get(language.lower(), "text")
                 try:
+                    # Use word_wrap to prevent extremely wide output
                     syntax = Syntax(
                         paste_data["content"],
                         lexer,
                         theme="monokai",
                         line_numbers=True,
+                        word_wrap=True,
                     )
-                    console.print(syntax)
+                    # Print syntax with auto width (not the large MAX_LINE_WIDTH)
+                    from rich.console import Console as SyntaxConsole
+
+                    syntax_console = SyntaxConsole()
+                    syntax_console.print(syntax)
                 except Exception:
                     # Fall back to plain text if syntax highlighting fails
                     console.print(paste_data["content"])

--- a/phabfive/paste/core.py
+++ b/phabfive/paste/core.py
@@ -171,24 +171,22 @@ class Paste(Phabfive):
         for paste in pastes:
             paste_data = {
                 "id": f"P{paste['id']}",
-                "phid": paste["phid"],
                 "title": paste["fields"].get("title", ""),
                 "language": paste["fields"].get("language") or "text",
                 "status": paste["fields"].get("status", "active"),
                 "dateCreated": paste["fields"].get("dateCreated"),
                 "dateModified": paste["fields"].get("dateModified"),
-                "authorPHID": paste["fields"].get("authorPHID"),
             }
+
+            # Resolve author name from PHID
+            author_phid = paste["fields"].get("authorPHID")
+            if author_phid:
+                paste_data["author"] = self._resolve_phid_to_name(author_phid)
 
             # Add content if requested and available
             if show_content and "attachments" in paste:
                 content_attachment = paste["attachments"].get("content", {})
                 paste_data["content"] = content_attachment.get("content", "")
-
-            # Resolve author name
-            author_phid = paste_data.get("authorPHID")
-            if author_phid:
-                paste_data["author"] = self._resolve_phid_to_name(author_phid)
 
             result.append(paste_data)
 

--- a/phabfive/paste/core.py
+++ b/phabfive/paste/core.py
@@ -169,8 +169,12 @@ class Paste(Phabfive):
 
         result = []
         for paste in pastes:
+            monogram = f"P{paste['id']}"
+            url = self.get_paste_url(paste["id"])
             paste_data = {
-                "id": f"P{paste['id']}",
+                "id": monogram,
+                "url": url,
+                "_link": self.format_link(url, monogram),
                 "title": paste["fields"].get("title", ""),
                 "language": paste["fields"].get("language") or "text",
                 "status": paste["fields"].get("status", "active"),


### PR DESCRIPTION
## Summary

- Require at least one search criterion for `paste search` (consistent with maniphest/passphrase)
- Remove internal PHIDs from output (phid, authorPHID)
- Add `Link` field to all output formats
- Implement all output formats consistently with passphrase/maniphest:
  - **rich**: YAML-like format with hyperlinks
  - **tree**: URL as root with fields as branches
  - **yaml**: Capitalized keys, block scalar for multi-line content
  - **json**: Capitalized keys
  - **simple**: Just content for piping

## Test plan

- [x] `phabfive paste search` shows usage (requires criteria)
- [x] `phabfive --format=rich paste show P9` shows YAML-like output
- [x] `phabfive --format=tree paste show P9` shows tree structure
- [x] `phabfive --format=yaml paste show P9` shows proper YAML
- [x] `phabfive --format=json paste show P9` shows proper JSON
- [x] `phabfive --format=simple paste show P9` outputs just content
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)