### PR TITLE
feat: Add dates to paste and passphrase output, remove rich quoting

### DIFF
--- a/phabfive/cli/paste.py
+++ b/phabfive/cli/paste.py
@@ -3,6 +3,7 @@
 
 import re
 import sys
+from datetime import datetime
 from typing import List, Optional
 
 import typer
@@ -344,6 +345,13 @@ def show(
     _display_pastes(result, output_format, paste)
 
 
+def _format_timestamp(ts):
+    """Convert Unix timestamp to ISO format string."""
+    if ts:
+        return datetime.fromtimestamp(ts).strftime("%Y-%m-%dT%H:%M:%S")
+    return None
+
+
 def _display_pastes(result, output_format, paste_instance):
     """Display paste results in the specified format."""
     import json
@@ -363,6 +371,8 @@ def _display_pastes(result, output_format, paste_instance):
                 "Author": p.get("author", ""),
                 "Language": p.get("language", "text"),
                 "Status": p.get("status", ""),
+                "Created": _format_timestamp(p.get("dateCreated")),
+                "Modified": _format_timestamp(p.get("dateModified")),
             }
             if "content" in p:
                 item["Content"] = p.get("content", "")
@@ -380,6 +390,8 @@ def _display_pastes(result, output_format, paste_instance):
                 "Author": p.get("author", ""),
                 "Language": p.get("language", "text"),
                 "Status": p.get("status", ""),
+                "Created": _format_timestamp(p.get("dateCreated")),
+                "Modified": _format_timestamp(p.get("dateModified")),
             }
             if "content" in p:
                 content = p.get("content", "")
@@ -405,6 +417,12 @@ def _display_pastes(result, output_format, paste_instance):
                 tree.add(f"Language: {paste_data['language']}")
             if paste_data.get("status"):
                 tree.add(f"Status: {paste_data['status']}")
+            created = _format_timestamp(paste_data.get("dateCreated"))
+            if created:
+                tree.add(f"Created: {created}")
+            modified = _format_timestamp(paste_data.get("dateModified"))
+            if modified:
+                tree.add(f"Modified: {modified}")
             if paste_data.get("content"):
                 # Show content preview for tree view
                 content = paste_data["content"]
@@ -448,6 +466,14 @@ def _display_pastes(result, output_format, paste_instance):
             # Print Status
             if paste_data.get("status"):
                 console.print(f"  Status: {paste_data['status']}")
+
+            # Print dates
+            created = _format_timestamp(paste_data.get("dateCreated"))
+            if created:
+                console.print(f"  Created: {created}")
+            modified = _format_timestamp(paste_data.get("dateModified"))
+            if modified:
+                console.print(f"  Modified: {modified}")
 
             # Print Content (only when present and non-empty)
             content = paste_data.get("content", "")

--- a/phabfive/display.py
+++ b/phabfive/display.py
@@ -87,9 +87,6 @@ def _display_task_rich(console, task_dict, phabfive_instance):
             console.print(f"    {key}: |-")
             for line in str(value).splitlines():
                 console.print(f"      {_escape_for_rich(line)}")
-        elif _needs_yaml_quoting(value):
-            escaped = str(value).replace("'", "''")
-            console.print(f"    {key}: '{_escape_for_rich(escaped)}'")
         else:
             console.print(f"    {key}: {_escape_for_rich(value)}")
 

--- a/phabfive/passphrase/core.py
+++ b/phabfive/passphrase/core.py
@@ -133,6 +133,33 @@ class Passphrase(Phabfive):
         data = self.get_passphrase(ids)
         return data["secret"]
 
+    def _get_credential_dates(self, phid):
+        """Get creation and modification dates from transaction history.
+
+        Parameters
+        ----------
+        phid : str
+            The PHID of the credential
+
+        Returns
+        -------
+        tuple
+            (dateCreated, dateModified) as Unix timestamps, or (None, None)
+        """
+        try:
+            response = self.phab.transaction.search(objectIdentifier=phid)
+            transactions = response.get("data", [])
+            if not transactions:
+                return (None, None)
+
+            # Get min dateCreated (oldest transaction = creation time)
+            # Get max dateModified (most recent modification)
+            created = min(t.get("dateCreated", 0) for t in transactions)
+            modified = max(t.get("dateModified", 0) for t in transactions)
+            return (created if created else None, modified if modified else None)
+        except (APIError, Exception):
+            return (None, None)
+
     def _format_credential(self, data, need_secrets=True, need_public_keys=False):
         """Format a single credential from API response.
 
@@ -203,6 +230,15 @@ class Passphrase(Phabfive):
 
         if need_public_keys and public_key:
             result["public_key"] = public_key
+
+        # Get dates from transaction history
+        phid = data.get("phid")
+        if phid:
+            date_created, date_modified = self._get_credential_dates(phid)
+            if date_created:
+                result["dateCreated"] = date_created
+            if date_modified:
+                result["dateModified"] = date_modified
 
         return result
 

--- a/phabfive/passphrase/display.py
+++ b/phabfive/passphrase/display.py
@@ -3,12 +3,20 @@
 
 import json
 import sys
+from datetime import datetime
 from io import StringIO
 
 from rich.text import Text
 from rich.tree import Tree
 from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import PreservedScalarString
+
+
+def _format_timestamp(ts):
+    """Convert Unix timestamp to ISO format string."""
+    if ts:
+        return datetime.fromtimestamp(ts).strftime("%Y-%m-%dT%H:%M:%S")
+    return None
 
 
 def display_passphrase_rich(console, passphrase_dict, phabfive_instance):
@@ -60,6 +68,14 @@ def display_passphrase_rich(console, passphrase_dict, phabfive_instance):
                 console.print(f"    {line}")
         else:
             console.print(f"  PublicKey: {public_key}")
+
+    # Print dates
+    created = _format_timestamp(passphrase_dict.get("dateCreated"))
+    if created:
+        console.print(f"  Created: {created}")
+    modified = _format_timestamp(passphrase_dict.get("dateModified"))
+    if modified:
+        console.print(f"  Modified: {modified}")
 
 
 def display_passphrase_tree(console, passphrase_dict, phabfive_instance):
@@ -113,6 +129,14 @@ def display_passphrase_tree(console, passphrase_dict, phabfive_instance):
         else:
             tree.add(f"PublicKey: {public_key_stripped}")
 
+    # Show dates
+    created = _format_timestamp(passphrase_dict.get("dateCreated"))
+    if created:
+        tree.add(f"Created: {created}")
+    modified = _format_timestamp(passphrase_dict.get("dateModified"))
+    if modified:
+        tree.add(f"Modified: {modified}")
+
     console.print(tree)
 
 
@@ -157,6 +181,14 @@ def display_passphrase_yaml(passphrase_dict):
         else:
             output["PublicKey"] = public_key
 
+    # Include dates
+    created = _format_timestamp(passphrase_dict.get("dateCreated"))
+    if created:
+        output["Created"] = created
+    modified = _format_timestamp(passphrase_dict.get("dateModified"))
+    if modified:
+        output["Modified"] = modified
+
     stream = StringIO()
     yaml.dump([output], stream)
     print(stream.getvalue(), end="")
@@ -190,6 +222,14 @@ def display_passphrase_json(passphrase_dict):
     public_key = passphrase_dict.get("public_key")
     if public_key:
         output["PublicKey"] = public_key
+
+    # Include dates
+    created = _format_timestamp(passphrase_dict.get("dateCreated"))
+    if created:
+        output["Created"] = created
+    modified = _format_timestamp(passphrase_dict.get("dateModified"))
+    if modified:
+        output["Modified"] = modified
 
     print(json.dumps(output, indent=2))  # noqa: T201  # lgtm[py/clear-text-logging-sensitive-data]
 
@@ -315,6 +355,14 @@ def display_passphrases_yaml(credentials, show_secrets=True):
             else:
                 item["PublicKey"] = public_key
 
+        # Include dates
+        created = _format_timestamp(cred.get("dateCreated"))
+        if created:
+            item["Created"] = created
+        modified = _format_timestamp(cred.get("dateModified"))
+        if modified:
+            item["Modified"] = modified
+
         output.append(item)
 
     stream = StringIO()
@@ -349,6 +397,14 @@ def display_passphrases_json(credentials, show_secrets=True):
 
         if "public_key" in cred:
             item["PublicKey"] = cred.get("public_key", "")
+
+        # Include dates
+        created = _format_timestamp(cred.get("dateCreated"))
+        if created:
+            item["Created"] = created
+        modified = _format_timestamp(cred.get("dateModified"))
+        if modified:
+            item["Modified"] = modified
 
         output.append(item)
 

--- a/tests/test_maniphest.py
+++ b/tests/test_maniphest.py
@@ -1198,7 +1198,8 @@ class TestYAMLQuoting:
 
         from phabfive.display import display_tasks
 
-        display_tasks(result, "rich", maniphest)
+        # Test yaml format (not rich) for YAML validity
+        display_tasks(result, "yaml", maniphest)
 
         captured = capsys.readouterr()
         yaml_output = captured.out
@@ -1263,7 +1264,8 @@ class TestYAMLQuoting:
 
         from phabfive.display import display_tasks
 
-        display_tasks(result, "rich", maniphest)
+        # Test yaml format (not rich) for YAML validity
+        display_tasks(result, "yaml", maniphest)
 
         captured = capsys.readouterr()
         yaml_output = captured.out
@@ -1329,7 +1331,8 @@ class TestYAMLQuoting:
 
         from phabfive.display import display_tasks
 
-        display_tasks(result, "rich", maniphest)
+        # Test yaml format (not rich) for YAML validity
+        display_tasks(result, "yaml", maniphest)
 
         captured = capsys.readouterr()
         yaml_output = captured.out
@@ -1397,7 +1400,8 @@ class TestYAMLQuoting:
 
         from phabfive.display import display_tasks
 
-        display_tasks(result, "rich", maniphest)
+        # Test yaml format (not rich) for YAML validity
+        display_tasks(result, "yaml", maniphest)
 
         captured = capsys.readouterr()
         yaml_output = captured.out
@@ -1463,7 +1467,8 @@ class TestYAMLQuoting:
 
         from phabfive.display import display_tasks
 
-        display_tasks(result, "rich", maniphest)
+        # Test yaml format (not rich) for YAML validity
+        display_tasks(result, "yaml", maniphest)
 
         captured = capsys.readouterr()
         yaml_output = captured.out
@@ -1609,7 +1614,8 @@ class TestStrictFormat:
 
         from phabfive.display import display_tasks
 
-        display_tasks(result, "rich", maniphest)
+        # Test strict/yaml format for YAML validity
+        display_tasks(result, "strict", maniphest)
 
         captured = capsys.readouterr()
         yaml_output = captured.out


### PR DESCRIPTION
## Summary

- Add `Created` and `Modified` date fields to paste output in all formats
- Add `Created` and `Modified` date fields to passphrase output (fetched from transaction history)
- Remove YAML quoting from rich terminal output (quoting only needed for actual YAML)

## Test plan

- [x] `phabfive paste show P1` shows dates
- [x] `phabfive --format=yaml paste show P1` shows dates
- [x] `phabfive --format=json paste show P1` shows dates
- [x] `phabfive K1` shows dates (fetched from transactions)
- [x] `phabfive --format=yaml K1` shows dates
- [x] `phabfive --format=json K1` shows dates
- [x] `phabfive T1` rich format no longer has quoted dates
- [x] `uv run ruff check phabfive/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)