### PR TITLE
feat: Add --limit to search and --no-description to maniphest show

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,14 +38,14 @@ gh pr merge --rebase --delete-branch
 
 ## Pre-commit Checks
 
-**Always run before committing:**
+**IMPORTANT: Always run before committing and pushing:**
 
 ```bash
 uv run ruff check phabfive/ tests/
 uv run ruff format phabfive/ tests/
 ```
 
-CI will fail if files are not properly formatted.
+CI will fail if files are not properly formatted. Run these commands before every commit to avoid CI failures.
 
 ## Architecture
 

--- a/phabfive/cli/maniphest.py
+++ b/phabfive/cli/maniphest.py
@@ -65,7 +65,7 @@ def _setup_output_options(ctx: typer.Context):
         )
 
 
-def _display_tasks(result, output_format, maniphest_instance):
+def _display_tasks(result, output_format, maniphest_instance, show_description=True):
     """Display task search/show results in the specified format."""
     from phabfive.display import (
         display_tasks_json,
@@ -82,13 +82,17 @@ def _display_tasks(result, output_format, maniphest_instance):
     try:
         tasks = result["tasks"]
         if output_format == "json":
-            display_tasks_json(tasks)
+            display_tasks_json(tasks, show_description=show_description)
         elif output_format == "tree":
-            display_tasks_tree(console, tasks, maniphest_instance)
+            display_tasks_tree(
+                console, tasks, maniphest_instance, show_description=show_description
+            )
         elif output_format in ("yaml", "strict"):
-            display_tasks_yaml(tasks)
+            display_tasks_yaml(tasks, show_description=show_description)
         else:  # "rich" (default)
-            display_tasks_rich(console, tasks, maniphest_instance)
+            display_tasks_rich(
+                console, tasks, maniphest_instance, show_description=show_description
+            )
     except BrokenPipeError:
         sys.stderr.close()
         sys.exit(0)
@@ -106,6 +110,9 @@ def show(
     ),
     show_comments: bool = typer.Option(
         False, "--show-comments", "-C", help="Display comments on the task"
+    ),
+    no_description: bool = typer.Option(
+        False, "--no-description", "-n", help="Hide the task description"
     ),
 ) -> None:
     """Show details for one or more Maniphest tasks."""
@@ -128,10 +135,13 @@ def show(
         show_history=show_history,
         show_metadata=show_metadata,
         show_comments=show_comments,
+        show_description=not no_description,
     )
 
     output_format = _get_output_format(ctx)
-    _display_tasks(result, output_format, maniphest)
+    _display_tasks(
+        result, output_format, maniphest, show_description=not no_description
+    )
 
 
 @maniphest_app.command()
@@ -382,6 +392,7 @@ def search(
     show_metadata: bool = typer.Option(
         False, "--show-metadata", help="Display filter match metadata"
     ),
+    limit: int = typer.Option(100, "--limit", "-l", help="Maximum results to return"),
 ) -> None:
     """Search for Maniphest tasks."""
     from phabfive.transitions import parse_column_patterns, parse_priority_patterns
@@ -481,6 +492,12 @@ def search(
             "all",
             False,
         )
+        final_limit = get_param(
+            limit if limit != 100 else None,
+            yaml_params,
+            "limit",
+            100,
+        )
 
         # Check if any search criteria provided
         has_criteria = any(
@@ -516,6 +533,7 @@ def search(
             show_history=final_show_history,
             show_metadata=final_show_metadata,
             include_closed=final_include_closed,
+            limit=final_limit,
         )
 
         output_format = _get_output_format(ctx)

--- a/phabfive/cli/paste.py
+++ b/phabfive/cli/paste.py
@@ -75,6 +75,7 @@ def search(
     author: Optional[str] = typer.Option(
         None, "--author", help="Filter by author (username or @me)"
     ),
+    limit: int = typer.Option(100, "--limit", "-l", help="Maximum results to return"),
 ) -> None:
     """Search and list pastes with optional filters.
 
@@ -117,7 +118,9 @@ def search(
         constraints["authorPHIDs"] = [author_phid]
 
     # Get pastes with constraints
-    pastes = paste.get_pastes(constraints=constraints if constraints else None)
+    pastes = paste.get_pastes(
+        constraints=constraints if constraints else None, limit=limit
+    )
 
     if not pastes:
         typer.echo("No pastes found")

--- a/phabfive/display.py
+++ b/phabfive/display.py
@@ -50,7 +50,7 @@ def _needs_yaml_quoting(value):
     return value == "" or any(c in value for c in ":{}[]`'\"")
 
 
-def _display_task_rich(console, task_dict, phabfive_instance):
+def _display_task_rich(console, task_dict, phabfive_instance, show_description=True):
     """Display a single task in YAML-like format using Rich.
 
     Parameters
@@ -61,6 +61,8 @@ def _display_task_rich(console, task_dict, phabfive_instance):
         Task data dictionary with _link, _url, _assignee, Task, Boards, etc.
     phabfive_instance : Phabfive
         Instance to access format_link() and url
+    show_description : bool
+        If True, include task description in output
     """
     # Extract internal fields
     link = task_dict.get("_link")
@@ -79,6 +81,10 @@ def _display_task_rich(console, task_dict, phabfive_instance):
     # Print Task section
     console.print("  Task:")
     for key, value in task_data.items():
+        # Skip description if show_description is False
+        if key == "Description" and not show_description:
+            continue
+
         # Check line width before printing
         phabfive_instance.check_line_width(value, f"Task.{key}")
 
@@ -194,7 +200,7 @@ def _display_task_rich(console, task_dict, phabfive_instance):
                 console.print(f"    {meta_key}: {_escape_for_rich(meta_value)}")
 
 
-def _display_task_tree(console, task_dict, phabfive_instance):
+def _display_task_tree(console, task_dict, phabfive_instance, show_description=True):
     """Display a single task in tree format using Rich Tree.
 
     Parameters
@@ -205,6 +211,8 @@ def _display_task_tree(console, task_dict, phabfive_instance):
         Task data dictionary with _link, _url, _assignee, Task, Boards, etc.
     phabfive_instance : Phabfive
         Instance to access format_link() and url
+    show_description : bool
+        If True, include task description in output
     """
     # Extract internal fields
     link = task_dict.get("_link")
@@ -223,6 +231,10 @@ def _display_task_tree(console, task_dict, phabfive_instance):
     # Add Task section
     task_branch = tree.add("Task")
     for key, value in task_data.items():
+        # Skip description if show_description is False
+        if key == "Description" and not show_description:
+            continue
+
         if isinstance(value, (str, PreservedScalarString)) and "\n" in str(value):
             # Truncate multi-line descriptions in tree view
             first_line = str(value).split("\n")[0]
@@ -332,17 +344,29 @@ def _display_task_tree(console, task_dict, phabfive_instance):
     console.print(tree)
 
 
-def _display_task_yaml(task_dict):
-    """Display a single task as strict YAML via ruamel.yaml."""
+def _display_task_yaml(task_dict, show_description=True):
+    """Display a single task as strict YAML via ruamel.yaml.
+
+    Parameters
+    ----------
+    task_dict : dict
+        Task data dictionary
+    show_description : bool
+        If True, include task description in output
+    """
     yaml = YAML()
     yaml.default_flow_style = False
 
     # Build clean dict - use _url for the Link (plain URL string)
     output = {"Link": task_dict.get("_url", "")}
 
-    # Add Task section
+    # Add Task section (filter out Description if show_description is False)
     if task_dict.get("Task"):
-        output["Task"] = {k: v for k, v in task_dict["Task"].items()}
+        output["Task"] = {
+            k: v
+            for k, v in task_dict["Task"].items()
+            if show_description or k != "Description"
+        }
 
     # Add Assignee if present (extract plain text from Rich Text if needed)
     assignee = task_dict.get("_assignee")
@@ -402,13 +426,15 @@ def _display_task_yaml(task_dict):
     print(stream.getvalue(), end="")
 
 
-def _build_task_json_output(task_dict):
+def _build_task_json_output(task_dict, show_description=True):
     """Build a clean JSON-serializable dict from a task_dict.
 
     Parameters
     ----------
     task_dict : dict
         Task data dictionary with Link, Task, Boards, History, Metadata, etc.
+    show_description : bool
+        If True, include task description in output
 
     Returns
     -------
@@ -418,10 +444,13 @@ def _build_task_json_output(task_dict):
     # Build clean dict - use _url for the Link (plain URL string)
     output = {"Link": task_dict.get("_url", "")}
 
-    # Add Task section
+    # Add Task section (filter out Description if show_description is False)
     if task_dict.get("Task"):
         output["Task"] = {}
         for k, v in task_dict["Task"].items():
+            # Skip description if show_description is False
+            if k == "Description" and not show_description:
+                continue
             # Convert PreservedScalarString to plain string
             if isinstance(v, PreservedScalarString):
                 output["Task"][k] = str(v)
@@ -484,7 +513,7 @@ def _build_task_json_output(task_dict):
     return output
 
 
-def display_tasks_rich(console, task_dicts, phabfive_instance):
+def display_tasks_rich(console, task_dicts, phabfive_instance, show_description=True):
     """Display tasks in YAML-like format using Rich.
 
     Parameters
@@ -495,12 +524,16 @@ def display_tasks_rich(console, task_dicts, phabfive_instance):
         List of task data dictionaries.
     phabfive_instance : Phabfive
         Instance to access format_link() and url
+    show_description : bool
+        If True, include task description in output
     """
     for task_dict in task_dicts:
-        _display_task_rich(console, task_dict, phabfive_instance)
+        _display_task_rich(
+            console, task_dict, phabfive_instance, show_description=show_description
+        )
 
 
-def display_tasks_tree(console, task_dicts, phabfive_instance):
+def display_tasks_tree(console, task_dicts, phabfive_instance, show_description=True):
     """Display tasks in tree format using Rich Tree.
 
     Parameters
@@ -511,32 +544,43 @@ def display_tasks_tree(console, task_dicts, phabfive_instance):
         List of task data dictionaries.
     phabfive_instance : Phabfive
         Instance to access format_link() and url
+    show_description : bool
+        If True, include task description in output
     """
     for task_dict in task_dicts:
-        _display_task_tree(console, task_dict, phabfive_instance)
+        _display_task_tree(
+            console, task_dict, phabfive_instance, show_description=show_description
+        )
 
 
-def display_tasks_yaml(task_dicts):
+def display_tasks_yaml(task_dicts, show_description=True):
     """Display tasks as strict YAML.
 
     Parameters
     ----------
     task_dicts : list[dict]
         List of task data dictionaries.
+    show_description : bool
+        If True, include task description in output
     """
     for task_dict in task_dicts:
-        _display_task_yaml(task_dict)
+        _display_task_yaml(task_dict, show_description=show_description)
 
 
-def display_tasks_json(task_dicts):
+def display_tasks_json(task_dicts, show_description=True):
     """Display tasks as a valid JSON array.
 
     Parameters
     ----------
     task_dicts : list[dict]
         List of task data dictionaries.
+    show_description : bool
+        If True, include task description in output
     """
-    outputs = [_build_task_json_output(td) for td in task_dicts]
+    outputs = [
+        _build_task_json_output(td, show_description=show_description)
+        for td in task_dicts
+    ]
     print(json.dumps(outputs, indent=2))
 
 

--- a/phabfive/maniphest/core.py
+++ b/phabfive/maniphest/core.py
@@ -254,7 +254,12 @@ class Maniphest(Phabfive):
         return parse_status_patterns(patterns_str, api_response)
 
     def task_show(
-        self, task_ids, show_history=False, show_metadata=False, show_comments=False
+        self,
+        task_ids,
+        show_history=False,
+        show_metadata=False,
+        show_comments=False,
+        show_description=True,
     ):
         """
         Show one or more Phabricator Maniphest tasks with optional history and metadata.
@@ -271,6 +276,8 @@ class Maniphest(Phabfive):
             If True, display metadata (mainly useful for debugging, less useful for single task)
         show_comments : bool, optional
             If True, display comments on the task
+        show_description : bool, optional
+            If True, include task description in output. Default is True.
         """
         # Use maniphest.search API to fetch all tasks in one call
         result = self.phab.maniphest.search(
@@ -585,6 +592,7 @@ class Maniphest(Phabfive):
         show_history=False,
         show_metadata=False,
         include_closed=False,
+        limit=100,
     ):
         """
         Search for Phabricator Maniphest tasks with given parameters.
@@ -622,6 +630,7 @@ class Maniphest(Phabfive):
         include_closed (bool, optional): If True, include tasks with closed statuses
                       (resolved, wontfix, invalid, duplicate, spite). Default is False,
                       which filters out closed tasks at API level. --status filters are additive.
+        limit         (int, optional): Maximum number of tasks to return. Default is 100.
         """
         # Validation - require at least one filter
         has_any_filter = any(
@@ -1220,6 +1229,10 @@ class Maniphest(Phabfive):
                 search_params["created_after"] = created_after_original
             if created_before_original:
                 search_params["created_before"] = created_before_original
+
+        # Apply limit if specified
+        if limit and len(result_data) > limit:
+            result_data = result_data[:limit]
 
         # Use shared method to build task data
         return self._build_task_display_data(

--- a/phabfive/paste/core.py
+++ b/phabfive/paste/core.py
@@ -101,7 +101,9 @@ class Paste(Phabfive):
 
         return id_and_phid["object"]
 
-    def get_pastes(self, query_key=None, attachments=None, constraints=None):
+    def get_pastes(
+        self, query_key=None, attachments=None, constraints=None, limit=None
+    ):
         """Wrapper that connects to Phabricator and retrieves information about pastes.
 
         `query_key` defaults to "all".
@@ -109,6 +111,7 @@ class Paste(Phabfive):
         :type query_key: str
         :type attachments: dict
         :type constraints: dict
+        :type limit: int
 
         :rtype: dict
         """
@@ -116,11 +119,15 @@ class Paste(Phabfive):
         attachments = attachments or {}
         constraints = constraints or {}
 
-        response = self.phab.paste.search(
-            queryKey=query_key,
-            attachments=attachments,
-            constraints=constraints,
-        )
+        kwargs = {
+            "queryKey": query_key,
+            "attachments": attachments,
+            "constraints": constraints,
+        }
+        if limit is not None:
+            kwargs["limit"] = limit
+
+        response = self.phab.paste.search(**kwargs)
 
         pastes = response.get("data", {})
 


### PR DESCRIPTION
## Summary

- Add `--limit` / `-l` to `paste search` (default: 100)
- Add `--limit` / `-l` to `maniphest search` (default: 100)
- Add `--no-description` / `-n` to `maniphest show`

These align the CLI options across paste, passphrase, and maniphest apps:
- passphrase already had `--limit` for search
- passphrase already had `-n` (`--no-secret`) pattern for hiding sensitive data

## Test plan

- [x] All existing tests pass (98 tests)
- [x] `phabfive paste search --help` shows `--limit` / `-l`
- [x] `phabfive maniphest search --help` shows `--limit` / `-l`
- [x] `phabfive maniphest show --help` shows `--no-description` / `-n`
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)