### PR TITLE
feat: Enhance user whoami to enumerate all hosts

### DIFF
--- a/phabfive/cli/user.py
+++ b/phabfive/cli/user.py
@@ -5,23 +5,49 @@ import sys
 
 import typer
 
+from phabfive.core import Phabfive
 from phabfive.exceptions import PhabfiveConfigException
 
 user_app = typer.Typer(help="Information on users, setup wizard")
 
 
+def _get_output_format(ctx: typer.Context) -> str:
+    """Get the output format from context or auto-detect."""
+    format_arg = ctx.obj.get("format") if ctx.obj else None
+    if format_arg:
+        return format_arg
+    return Phabfive._get_auto_format()
+
+
+def _setup_output_options(ctx: typer.Context) -> None:
+    """Set global output options from context."""
+    if ctx.obj:
+        ascii_when = ctx.obj.get("ascii", "auto")
+        hyperlink_when = ctx.obj.get("hyperlink", "auto")
+        output_format = _get_output_format(ctx)
+        Phabfive.set_output_options(ascii_when, hyperlink_when, output_format)
+
+
 @user_app.command()
 def whoami(ctx: typer.Context) -> None:
-    """Display information about the currently authenticated user."""
+    """Show current user for all configured hosts in ~/.arcrc."""
     import requests
 
+    from phabfive.display import display_users
     from phabfive.user import User
+
+    _setup_output_options(ctx)
 
     try:
         user = User()
-        whoami_data = user.whoami()
-        for key, value in whoami_data.items():
-            typer.echo(f"{key}: {value}")
+        results = user.whoami_all_hosts()
+
+        if not results:
+            typer.echo("No hosts found in ~/.arcrc", err=True)
+            raise typer.Exit(1)
+
+        output_format = _get_output_format(ctx)
+        display_users(results, output_format, user)
     except PhabfiveConfigException as e:
         from phabfive.setup import offer_setup_on_error
 

--- a/phabfive/display.py
+++ b/phabfive/display.py
@@ -616,3 +616,193 @@ def display_tasks(result, output_format, phabfive_instance):
         # Quietly exit - this is normal behavior
         sys.stderr.close()
         sys.exit(0)
+
+
+# User display functions
+
+
+def _display_user_rich(console, user_dict, phabfive_instance):
+    """Display a single user/host in YAML-like format using Rich.
+
+    Parameters
+    ----------
+    console : Console
+        Rich Console instance for output
+    user_dict : dict
+        User data dictionary with Host, URL, User (or Error)
+    phabfive_instance : Phabfive
+        Instance to access format_link()
+    """
+    host = user_dict.get("Host", "")
+    url = user_dict.get("URL", "")
+    base_url = user_dict.get("_base_url", "")
+    user_data = user_dict.get("User")
+    error = user_dict.get("Error")
+
+    # Make host a clickable link to the base URL
+    if base_url:
+        host_link = phabfive_instance.format_link(base_url, host, show_url=False)
+        console.print(Text.assemble("- Host: ", host_link))
+    else:
+        console.print(f"- Host: {_escape_for_rich(host)}")
+    console.print(f"  URL: {_escape_for_rich(url)}")
+
+    if error:
+        console.print(f"  Error: {_escape_for_rich(error)}")
+    elif user_data:
+        console.print("  User:")
+        # Make UserName clickable if link is available
+        link = user_dict.get("_link")
+        if link:
+            console.print(Text.assemble("    UserName: ", link))
+        else:
+            console.print(
+                f"    UserName: {_escape_for_rich(user_data.get('UserName', ''))}"
+            )
+        console.print(
+            f"    RealName: {_escape_for_rich(user_data.get('RealName', ''))}"
+        )
+        console.print(
+            f"    PrimaryEmail: {_escape_for_rich(user_data.get('PrimaryEmail', ''))}"
+        )
+
+
+def _display_user_yaml(user_dict):
+    """Display a single user/host as strict YAML via ruamel.yaml.
+
+    Parameters
+    ----------
+    user_dict : dict
+        User data dictionary
+    """
+    yaml = YAML()
+    yaml.default_flow_style = False
+
+    # Build clean dict without internal keys
+    output = {
+        "Host": user_dict.get("Host", ""),
+        "URL": user_dict.get("URL", ""),
+    }
+
+    if user_dict.get("Error"):
+        output["Error"] = user_dict["Error"]
+    elif user_dict.get("User"):
+        output["User"] = user_dict["User"]
+
+    stream = StringIO()
+    yaml.dump([output], stream)
+    print(stream.getvalue(), end="")
+
+
+def _build_user_json_output(user_dict):
+    """Build a clean JSON-serializable dict from a user_dict.
+
+    Parameters
+    ----------
+    user_dict : dict
+        User data dictionary
+
+    Returns
+    -------
+    dict
+        Clean dictionary ready for JSON serialization.
+    """
+    output = {
+        "Host": user_dict.get("Host", ""),
+        "URL": user_dict.get("URL", ""),
+    }
+
+    if user_dict.get("Error"):
+        output["Error"] = user_dict["Error"]
+    elif user_dict.get("User"):
+        output["User"] = user_dict["User"]
+
+    return output
+
+
+def display_users_rich(console, user_dicts, phabfive_instance):
+    """Display users in YAML-like format using Rich.
+
+    Parameters
+    ----------
+    console : Console
+        Rich Console instance for output
+    user_dicts : list[dict]
+        List of user data dictionaries.
+    phabfive_instance : Phabfive
+        Instance to access format_link()
+    """
+    for user_dict in user_dicts:
+        _display_user_rich(console, user_dict, phabfive_instance)
+
+
+def display_users_yaml(user_dicts):
+    """Display users as strict YAML.
+
+    Parameters
+    ----------
+    user_dicts : list[dict]
+        List of user data dictionaries.
+    """
+    yaml = YAML()
+    yaml.default_flow_style = False
+
+    # Build clean list
+    outputs = []
+    for user_dict in user_dicts:
+        output = {
+            "Host": user_dict.get("Host", ""),
+            "URL": user_dict.get("URL", ""),
+        }
+        if user_dict.get("Error"):
+            output["Error"] = user_dict["Error"]
+        elif user_dict.get("User"):
+            output["User"] = user_dict["User"]
+        outputs.append(output)
+
+    stream = StringIO()
+    yaml.dump(outputs, stream)
+    print(stream.getvalue(), end="")
+
+
+def display_users_json(user_dicts):
+    """Display users as a valid JSON array.
+
+    Parameters
+    ----------
+    user_dicts : list[dict]
+        List of user data dictionaries.
+    """
+    outputs = [_build_user_json_output(ud) for ud in user_dicts]
+    print(json.dumps(outputs, indent=2))
+
+
+def display_users(user_dicts, output_format, phabfive_instance):
+    """Display user whoami results in the specified format.
+
+    Parameters
+    ----------
+    user_dicts : list[dict]
+        List of user data dictionaries from whoami_all_hosts()
+    output_format : str
+        One of 'rich', 'yaml', or 'json'
+    phabfive_instance : Phabfive
+        Instance to access formatting helpers
+    """
+    if not user_dicts:
+        return
+
+    console = phabfive_instance.get_console()
+
+    try:
+        if output_format == "json":
+            display_users_json(user_dicts)
+        elif output_format in ("yaml", "strict"):
+            display_users_yaml(user_dicts)
+        else:  # "rich" (default)
+            display_users_rich(console, user_dicts, phabfive_instance)
+    except BrokenPipeError:
+        # Handle pipe closed by consumer (e.g., head, less)
+        # Quietly exit - this is normal behavior
+        sys.stderr.close()
+        sys.exit(0)

--- a/phabfive/user.py
+++ b/phabfive/user.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
 
 # python std lib
+import json
 import logging
+import os
+import stat
+from urllib.parse import urlparse
 
 # 3rd party imports
-from phabricator import APIError
+from phabricator import APIError, Phabricator
 
 # phabfive imports
 from phabfive.core import Phabfive
-from phabfive.exceptions import PhabfiveRemoteException
+from phabfive.exceptions import PhabfiveConfigException, PhabfiveRemoteException
 
 log = logging.getLogger(__name__)
 
@@ -29,3 +33,109 @@ class User(Phabfive):
             for (key, value) in response.items()
             if key in ["userName", "realName", "primaryEmail", "uri"]
         }
+
+    def whoami_all_hosts(self):
+        """Run whoami against all hosts in ~/.arcrc.
+
+        Returns
+        -------
+        list[dict]
+            List of user info dicts, one per host. Each contains:
+            - Host: FQDN only (e.g., "dynamist.phacility.com")
+            - URL: Full API URL for PHAB_URL (e.g., "https://dynamist.phacility.com/api/")
+            - User: dict with UserName, RealName, PrimaryEmail, Link
+            - _link: Rich hyperlink to user profile (for rich format)
+            - Error: error message if whoami failed for this host (optional)
+        """
+        arcrc_path = os.path.expanduser("~/.arcrc")
+
+        if not os.path.exists(arcrc_path):
+            raise PhabfiveConfigException(f"No .arcrc file found at {arcrc_path}")
+
+        # Security check: ensure file has secure permissions
+        self._check_arcrc_permissions(arcrc_path)
+
+        try:
+            with open(arcrc_path, "r") as f:
+                arcrc_data = json.load(f)
+        except json.JSONDecodeError as e:
+            raise PhabfiveConfigException(f"Failed to parse {arcrc_path}: {e}")
+        except IOError as e:
+            raise PhabfiveConfigException(f"Failed to read {arcrc_path}: {e}")
+
+        hosts = arcrc_data.get("hosts", {})
+
+        if not hosts:
+            raise PhabfiveConfigException("No hosts found in ~/.arcrc")
+
+        results = []
+
+        for host_uri, host_data in hosts.items():
+            token = host_data.get("token")
+            normalized_url = self._normalize_url(host_uri)
+            parsed = urlparse(normalized_url)
+            fqdn = parsed.netloc
+            base_url = f"{parsed.scheme}://{parsed.netloc}"
+
+            result = {
+                "Host": fqdn,
+                "URL": normalized_url,
+                "_base_url": base_url,
+            }
+
+            if not token:
+                result["Error"] = "No token configured for this host"
+                results.append(result)
+                continue
+
+            try:
+                # Create a temporary Phabricator client for this host
+                phab = Phabricator(host=normalized_url, token=token)
+                phab.update_interfaces()
+                response = phab.user.whoami()
+
+                user_name = response.get("userName", "")
+                user_link = f"{base_url}/p/{user_name}/"
+
+                result["User"] = {
+                    "UserName": user_name,
+                    "RealName": response.get("realName", ""),
+                    "PrimaryEmail": response.get("primaryEmail", ""),
+                }
+
+                # Add _link for rich format (clickable hyperlink)
+                result["_link"] = self.format_link(user_link, user_name, show_url=False)
+
+            except APIError as e:
+                error_msg = str(e).replace("ERR-CONDUIT-CORE: ", "")
+                result["Error"] = error_msg
+            except Exception as e:
+                result["Error"] = str(e)
+
+            results.append(result)
+
+        return results
+
+    def _check_arcrc_permissions(self, file_path):
+        """Check that ~/.arcrc has secure permissions.
+
+        Note: This check is skipped on Windows.
+        """
+        # Skip permission check on Windows
+        if os.name == "nt":
+            return
+
+        if not os.path.exists(file_path):
+            return
+
+        file_stat = os.stat(file_path)
+        mode = file_stat.st_mode
+
+        # Check if group or others have any permissions
+        if mode & (stat.S_IRWXG | stat.S_IRWXO):
+            actual_perms = oct(mode & 0o777)
+            raise PhabfiveConfigException(
+                f"{file_path} has insecure permissions ({actual_perms}). "
+                "The file contains sensitive credentials and should only be readable by you. "
+                f"Please run: chmod 600 {file_path}"
+            )


### PR DESCRIPTION
## Summary

- Add `whoami_all_hosts()` method to enumerate all hosts in `~/.arcrc`
- Add user display functions (rich, yaml, json) to `display.py`
- Update CLI to support `--format` options for `user whoami`
- Each host shows FQDN (Host), API URL (URL), and User info (UserName, RealName, PrimaryEmail)
- Host and UserName are clickable links in rich format
- Graceful error handling per-host (shows Error field if whoami fails)

## Test plan

- [x] `phabfive user whoami` shows all hosts from ~/.arcrc
- [x] `phabfive --format=yaml user whoami` outputs valid YAML
- [x] `phabfive --format=json user whoami` outputs valid JSON
- [x] URL field can be used with `PHAB_URL=` for other commands
- [x] All tests pass (`uv run pytest tests/ -v`)
- [x] Linting passes (`uv run ruff check phabfive/ tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)