### PR TITLE
feat(countdown): Add countdown app with show, search, create, edit, comment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding agents when working with code in this r
 
 ## Project Overview
 
-phabfive is a CLI for Phabricator and Phorge. It provides commands for interacting with Passphrase, Diffusion, Paste, User, and Maniphest applications.
+phabfive is a CLI for Phabricator and Phorge. It provides commands for interacting with Countdown, Diffusion, Maniphest, Passphrase, Paste, and User applications.
 
 ## Common Commands
 
@@ -51,8 +51,8 @@ CI will fail if files are not properly formatted. Run these commands before ever
 
 ### CLI Layer (`cli/`)
 - Uses `typer` for argument parsing with built-in shell completion
-- Modular structure: `__init__.py` (main app), `maniphest.py`, `diffusion.py`, `paste.py`, `user.py`, `passphrase.py`, `repl.py`
-- Monogram shortcuts via `preprocess_monograms()`: `phabfive T123` expands to `phabfive maniphest show T123`
+- Modular structure: `__init__.py` (main app), `countdown.py`, `diffusion.py`, `maniphest.py`, `passphrase.py`, `paste.py`, `user.py`, `repl.py`
+- Monogram shortcuts via `preprocess_monograms()`: `phabfive T123` expands to `phabfive maniphest show T123`, `phabfive C123` expands to `phabfive countdown show C123`
 - Entry point: `cli_entrypoint()`
 - Shell completion: `phabfive --install-completion bash|zsh|fish`
 
@@ -73,7 +73,7 @@ Complex features use a consistent subpackage structure:
   - `validators.py` - input validation (diffusion, maniphest)
 
 ### Simpler Modules
-- `paste.py`, `user.py` - single-file implementations
+- `countdown/`, `paste/`, `user.py` - simpler implementations with core.py only
 - `transitions/` - state machine for task status/priority/column changes
 
 ### Configuration

--- a/phabfive/cli/__init__.py
+++ b/phabfive/cli/__init__.py
@@ -12,6 +12,7 @@ os.environ.setdefault("TYPER_USE_RICH", "0")
 
 import typer
 
+from phabfive.cli.countdown import countdown_app
 from phabfive.cli.diffusion import diffusion_app
 from phabfive.cli.edit import edit_command
 from phabfive.cli.maniphest import maniphest_app
@@ -210,6 +211,7 @@ def main(
     ctx.obj["hyperlink"] = hyperlink_when.value
 
 
+app.add_typer(countdown_app, name="countdown")
 app.add_typer(passphrase_app, name="passphrase")
 app.add_typer(diffusion_app, name="diffusion")
 app.command(name="edit")(edit_command)

--- a/phabfive/cli/countdown.py
+++ b/phabfive/cli/countdown.py
@@ -1,0 +1,510 @@
+# -*- coding: utf-8 -*-
+"""Countdown commands for phabfive CLI."""
+
+import re
+import sys
+from datetime import datetime
+from io import StringIO
+from typing import List, Optional
+
+import typer
+from rich.text import Text
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import PreservedScalarString
+
+from phabfive.constants import MONOGRAMS
+from phabfive.exceptions import PhabfiveConfigException, PhabfiveDataException
+
+countdown_app = typer.Typer(help="The countdown app")
+
+
+def _get_output_format(ctx: typer.Context):
+    """Get output format from context or auto-detect."""
+    from phabfive.core import Phabfive
+
+    format_arg = ctx.obj.get("format") if ctx.obj else None
+    if format_arg is None:
+        return Phabfive._get_auto_format()
+    return format_arg
+
+
+def _setup_output_options(ctx: typer.Context):
+    """Set up output options from context."""
+    from phabfive.core import Phabfive
+
+    if ctx.obj:
+        ascii_when = ctx.obj.get("ascii", "auto")
+        hyperlink_when = ctx.obj.get("hyperlink", "auto")
+        output_format = _get_output_format(ctx)
+
+        Phabfive.set_output_options(
+            ascii_when=ascii_when,
+            hyperlink_when=hyperlink_when,
+            output_format=output_format,
+        )
+
+
+def _get_countdown_app():
+    """Get Countdown app instance with config error handling."""
+    import requests
+
+    from phabfive.countdown import Countdown
+
+    try:
+        return Countdown()
+    except PhabfiveConfigException as e:
+        from phabfive.setup import offer_setup_on_error
+
+        if not offer_setup_on_error(str(e)):
+            raise typer.Exit(1)
+        # If setup succeeded, try again
+        return Countdown()
+    except requests.exceptions.RequestException as e:
+        sys.stderr.write(f"Error: Failed to connect to Phabricator API: {e}\n")
+        raise typer.Exit(1)
+
+
+def _format_timestamp(ts):
+    """Convert Unix timestamp to ISO format string."""
+    if ts:
+        return datetime.fromtimestamp(ts).strftime("%Y-%m-%dT%H:%M:%S")
+    return None
+
+
+def _display_countdowns(result, output_format, countdown_instance):
+    """Display countdown results in the specified format (matching maniphest UX)."""
+    import json
+
+    if not result or not result.get("countdowns"):
+        return
+
+    countdowns = result["countdowns"]
+
+    if output_format == "json":
+        output = []
+        for c in countdowns:
+            countdown_fields = c.get("Countdown", {})
+            item = {
+                "Link": c.get("_url", ""),
+                "Countdown": countdown_fields,
+            }
+            if c.get("_author"):
+                item["Countdown"]["Author"] = c.get("_author")
+            output.append(item)
+        print(json.dumps(output, indent=2))
+
+    elif output_format in ("yaml", "strict"):
+        yaml = YAML()
+        yaml.default_flow_style = False
+        output = []
+        for c in countdowns:
+            countdown_fields = dict(c.get("Countdown", {}))
+            # Handle multiline description
+            if "Description" in countdown_fields:
+                desc = countdown_fields["Description"]
+                if "\n" in desc:
+                    countdown_fields["Description"] = PreservedScalarString(desc)
+            if c.get("_author"):
+                countdown_fields["Author"] = c.get("_author")
+            item = {
+                "Link": c.get("_url", ""),
+                "Countdown": countdown_fields,
+            }
+            output.append(item)
+        stream = StringIO()
+        yaml.dump(output, stream)
+        print(stream.getvalue(), end="")
+
+    elif output_format == "tree":
+        from rich.tree import Tree
+
+        console = countdown_instance.get_console()
+        for c in countdowns:
+            countdown_fields = c.get("Countdown", {})
+            tree = Tree(c.get("_url", ""))
+            countdown_branch = tree.add("Countdown:")
+            for key, value in countdown_fields.items():
+                if key == "Description" and value and "\n" in value:
+                    desc_branch = countdown_branch.add("Description:")
+                    for line in value.splitlines()[:5]:
+                        desc_branch.add(line)
+                    if len(value.splitlines()) > 5:
+                        desc_branch.add("...")
+                else:
+                    countdown_branch.add(f"{key}: {value}")
+            if c.get("_author"):
+                countdown_branch.add(f"Author: {c.get('_author')}")
+            console.print(tree)
+
+    else:
+        # Rich format - YAML-like output with hyperlinks (matching maniphest)
+        console = countdown_instance.get_console()
+
+        for c in countdowns:
+            link = c.get("_link")
+            countdown_fields = c.get("Countdown", {})
+
+            # Print link
+            console.print(Text.assemble("- Link: ", link))
+
+            # Print Countdown section (like maniphest Task section)
+            console.print("  Countdown:")
+            for key, value in countdown_fields.items():
+                if key == "Description" and value and "\n" in str(value):
+                    # Multi-line value
+                    console.print(f"    {key}: |-")
+                    for line in str(value).splitlines():
+                        console.print(f"      {line}")
+                else:
+                    console.print(f"    {key}: {value}")
+
+            # Print Author (like maniphest Assignee)
+            if c.get("_author"):
+                console.print(f"    Author: {c.get('_author')}")
+
+
+@countdown_app.command()
+def show(
+    ctx: typer.Context,
+    countdown_ids: List[str] = typer.Argument(
+        ..., help="Countdown monogram(s) (e.g., C1 C2)"
+    ),
+) -> None:
+    """Show details for one or more countdowns.
+
+    \b
+    Examples:
+        phabfive countdown show C1
+        phabfive countdown show C1 C2
+        phabfive --format=yaml countdown show C1
+        phabfive C1  # monogram shortcut
+    """
+    _setup_output_options(ctx)
+    countdown = _get_countdown_app()
+
+    # Validate all countdown ID formats
+    countdown_pattern = f"^{MONOGRAMS['countdown']}$"
+    ids = []
+    for countdown_id in countdown_ids:
+        if not re.match(countdown_pattern, countdown_id):
+            typer.echo(
+                f"Invalid countdown ID '{countdown_id}'. Expected format: C123",
+                err=True,
+            )
+            raise typer.Exit(1)
+        ids.append(int(countdown_id[1:]))
+
+    result = countdown.countdown_show(ids)
+
+    output_format = _get_output_format(ctx)
+    _display_countdowns(result, output_format, countdown)
+
+
+@countdown_app.command()
+def search(
+    ctx: typer.Context,
+    text_query: Optional[str] = typer.Argument(
+        None, help="Free-text search in countdown title"
+    ),
+    author: Optional[str] = typer.Option(
+        None, "--author", help="Filter by author (username or @me)"
+    ),
+) -> None:
+    """Search and list countdowns with optional filters.
+
+    \b
+    Examples:
+        phabfive countdown search "launch"
+        phabfive countdown search --author=@me
+        phabfive --format=yaml countdown search "release"
+    """
+    if not text_query and not author:
+        typer.echo("Usage:")
+        typer.echo("    phabfive countdown search [<text_query>] [options]")
+        return
+
+    _setup_output_options(ctx)
+    countdown = _get_countdown_app()
+
+    constraints = {}
+
+    if text_query:
+        constraints["query"] = text_query
+
+    if author:
+        if author == "@me":
+            whoami = countdown.phab.user.whoami()
+            author_phid = whoami.get("phid")
+        else:
+            users = countdown.phab.user.search(constraints={"usernames": [author]})
+            if users.get("data"):
+                author_phid = users["data"][0]["phid"]
+            else:
+                sys.stderr.write(f"Error: User '{author}' not found\n")
+                raise typer.Exit(1)
+        constraints["authorPHIDs"] = [author_phid]
+
+    countdowns = countdown.get_countdowns(
+        constraints=constraints if constraints else None
+    )
+
+    if not countdowns:
+        typer.echo("No countdowns found")
+        return
+
+    output_format = _get_output_format(ctx)
+
+    if output_format == "json":
+        import json
+
+        result = [
+            {"id": f"C{c['id']}", "title": c["fields"]["name"]} for c in countdowns
+        ]
+        print(json.dumps(result, indent=2))
+    elif output_format in ("yaml", "strict"):
+        result = [
+            {"id": f"C{c['id']}", "title": c["fields"]["name"]} for c in countdowns
+        ]
+        yaml = YAML()
+        yaml.default_flow_style = False
+        stream = StringIO()
+        yaml.dump(result, stream)
+        print(stream.getvalue(), end="")
+    else:
+        for c in countdowns:
+            typer.echo(f"C{c['id']} {c['fields']['name']}")
+
+
+@countdown_app.command()
+def create(
+    ctx: typer.Context,
+    title: str = typer.Argument(..., help="Title for the countdown"),
+    epoch: str = typer.Argument(
+        ..., help="Target date (ISO 8601, +7d relative, or Unix timestamp)"
+    ),
+    description: Optional[str] = typer.Option(
+        None, "--description", help="Countdown description"
+    ),
+    tag: Optional[List[str]] = typer.Option(
+        None, "--tag", help="Add to project (repeatable)"
+    ),
+    subscribe: Optional[List[str]] = typer.Option(
+        None, "--subscribe", help="Add subscriber (username or @me, repeatable)"
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without creating"),
+) -> None:
+    """Create a new countdown.
+
+    \b
+    Epoch format examples:
+        2026-06-15T10:00:00    # ISO 8601
+        2026-06-15             # Date only (midnight)
+        +7d                    # 7 days from now
+        +2w                    # 2 weeks from now
+        +1m                    # 1 month (30 days) from now
+        +4h                    # 4 hours from now
+
+    \b
+    Examples:
+        phabfive countdown create "Product Launch" "2026-06-15T10:00:00"
+        phabfive countdown create "Sprint End" +2w
+        phabfive countdown create "Release" +7d --description="v2.0 release"
+        phabfive countdown create "Demo" +4h --subscribe=@me
+    """
+    countdown = _get_countdown_app()
+
+    # Handle @me shortcut for subscribers
+    subscriber_names = []
+    if subscribe:
+        for sub in subscribe:
+            if sub == "@me":
+                whoami = countdown.phab.user.whoami()
+                subscriber_names.append(whoami.get("userName", sub))
+            else:
+                subscriber_names.append(sub)
+
+    tag_list = list(tag) if tag else None
+
+    if dry_run:
+        # Parse epoch for display
+        epoch_ts = countdown.parse_epoch(epoch)
+        epoch_formatted = countdown._format_epoch(epoch_ts)
+
+        print("[DRY RUN] Would create countdown:")
+        print(f"  Title: {title}")
+        print(f"  Epoch: {epoch_formatted}")
+        if description:
+            print(f"  Description: {description}")
+        if tag_list:
+            print(f"  Tags: {', '.join(tag_list)}")
+        if subscriber_names:
+            print(f"  Subscribers: {', '.join(subscriber_names)}")
+        raise typer.Exit(0)
+
+    try:
+        result = countdown.create_countdown(
+            title=title,
+            epoch=epoch,
+            description=description,
+            tags=tag_list,
+            subscribers=subscriber_names if subscriber_names else None,
+        )
+    except PhabfiveDataException as e:
+        sys.stderr.write(f"Error: {e}\n")
+        raise typer.Exit(1)
+
+    print(countdown.get_countdown_url(result["id"]))
+
+
+@countdown_app.command()
+def edit(
+    ctx: typer.Context,
+    countdown_id: str = typer.Argument(..., help="Countdown monogram (e.g., C123)"),
+    title: Optional[str] = typer.Argument(None, help="New title"),
+    title_opt: Optional[str] = typer.Option(
+        None,
+        "--title",
+        hidden=True,
+        help="New title (hidden, use positional argument instead)",
+    ),
+    epoch: Optional[str] = typer.Option(
+        None,
+        "--epoch",
+        help="New target date (ISO 8601, +7d relative, or Unix timestamp)",
+    ),
+    description: Optional[str] = typer.Option(
+        None, "--description", help="New description"
+    ),
+    tag: Optional[List[str]] = typer.Option(
+        None, "--tag", help="Add to project (repeatable)"
+    ),
+    subscribe: Optional[List[str]] = typer.Option(
+        None, "--subscribe", help="Add subscriber (username or @me, repeatable)"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview changes without applying"
+    ),
+) -> None:
+    """Edit an existing countdown.
+
+    \b
+    Examples:
+        phabfive countdown edit C1 "New Title"
+        phabfive countdown edit C1 --epoch=+14d
+        phabfive countdown edit C1 --epoch="2026-07-01T00:00:00"
+        phabfive countdown edit C1 --description="Updated description"
+        phabfive countdown edit C1 --subscribe=@me --tag=project
+    """
+    _setup_output_options(ctx)
+    countdown = _get_countdown_app()
+
+    # Merge positional and option title (positional takes precedence)
+    final_title = title or title_opt
+
+    countdown_pattern = f"^{MONOGRAMS['countdown']}$"
+    if not re.match(countdown_pattern, countdown_id):
+        sys.stderr.write(
+            f"Error: Invalid countdown ID '{countdown_id}'. Expected format: C123\n"
+        )
+        raise typer.Exit(1)
+
+    numeric_id = int(countdown_id[1:])
+
+    # Handle @me shortcut for subscribers
+    subscriber_names = []
+    if subscribe:
+        for sub in subscribe:
+            if sub == "@me":
+                whoami = countdown.phab.user.whoami()
+                subscriber_names.append(whoami.get("userName", sub))
+            else:
+                subscriber_names.append(sub)
+
+    tag_list = list(tag) if tag else None
+
+    try:
+        result = countdown.edit_countdown(
+            countdown_id=numeric_id,
+            title=final_title,
+            epoch=epoch,
+            description=description,
+            tags=tag_list,
+            subscribers=subscriber_names if subscriber_names else None,
+            dry_run=dry_run,
+        )
+    except PhabfiveDataException as e:
+        sys.stderr.write(f"Error: {e}\n")
+        raise typer.Exit(1)
+
+    if dry_run:
+        print(f"[DRY RUN] Would edit {countdown_id}:")
+        for change in result.get("changes", []):
+            print(f"  {change['field']}: {change['new']}")
+        if not result.get("changes"):
+            print("  No changes specified")
+    else:
+        if result.get("changes"):
+            print(f"Updated {countdown_id}")
+            for change in result["changes"]:
+                print(f"  {change['field']}: {change['new']}")
+        else:
+            print(result.get("message", "No changes made"))
+
+
+@countdown_app.command()
+def comment(
+    ctx: typer.Context,
+    countdown_id: str = typer.Argument(..., help="Countdown monogram (e.g., C123)"),
+    text: Optional[str] = typer.Argument(
+        None, help="Comment text (omit to open $EDITOR)"
+    ),
+) -> None:
+    """Add a comment to a countdown.
+
+    \b
+    Examples:
+        phabfive countdown comment C1 "Looking forward to this!"
+        phabfive countdown comment C1  # opens $EDITOR
+        echo "comment" | phabfive countdown comment C1 -
+        phabfive C1 "Quick comment"  # monogram shortcut
+    """
+    from phabfive.editor import edit_text
+
+    countdown = _get_countdown_app()
+
+    countdown_pattern = f"^{MONOGRAMS['countdown']}$"
+    if not re.match(countdown_pattern, countdown_id):
+        sys.stderr.write(
+            f"Error: Invalid countdown ID '{countdown_id}'. Expected format: C123\n"
+        )
+        raise typer.Exit(1)
+
+    numeric_id = int(countdown_id[1:])
+
+    final_text = None
+    if text == "-":
+        if sys.stdin.isatty():
+            sys.stderr.write("Error: '-' requires input from stdin\n")
+            raise typer.Exit(1)
+        final_text = sys.stdin.read().strip()
+    elif text is not None:
+        final_text = text
+    else:
+        if not sys.stdin.isatty():
+            sys.stderr.write("Error: Provide comment text or run interactively\n")
+            raise typer.Exit(1)
+        final_text = edit_text("", prefix="countdown-comment-", suffix=".remarkup")
+        if final_text is None:
+            print("Comment cancelled")
+            raise typer.Exit(0)
+
+    if not final_text:
+        sys.stderr.write("Error: Comment cannot be empty\n")
+        raise typer.Exit(1)
+
+    try:
+        countdown.add_countdown_comment(numeric_id, final_text)
+        print(countdown.get_countdown_url(numeric_id))
+    except Exception as e:
+        sys.stderr.write(f"Error: {e}\n")
+        raise typer.Exit(1)

--- a/phabfive/constants.py
+++ b/phabfive/constants.py
@@ -32,6 +32,7 @@ class LogLevel(str, Enum):
 
 # https://secure.phabricator.com/w/object_name_prefixes/
 MONOGRAMS = {
+    "countdown": "C[0-9]+",
     "diffusion": "R[0-9]+",
     "passphrase": "K[0-9]+",
     "paste": "P[0-9]+",
@@ -40,6 +41,7 @@ MONOGRAMS = {
 
 # Monogram shortcuts for CLI: maps prefix letter to command expansion
 MONOGRAM_SHORTCUT = {
+    "C": ["countdown", "show"],  # C123 → countdown show C123
     "T": ["maniphest", "show"],  # T123 → maniphest show T123
     "K": ["passphrase", "show"],  # K123 → passphrase show K123
     "P": ["paste", "show"],  # P123 → paste show P123
@@ -47,7 +49,7 @@ MONOGRAM_SHORTCUT = {
 }
 
 # Apps that support "X123 'text'" → "app comment X123 'text'" shortcut
-COMMENTS_SUPPORTED = ["maniphest", "paste"]
+COMMENTS_SUPPORTED = ["countdown", "maniphest", "paste"]
 
 # Default languages for paste syntax highlighting (from Phabricator pygments.dropdown-choices)
 # These are the languages shown in the Phabricator/Phorge Paste language dropdown by default.

--- a/phabfive/countdown/__init__.py
+++ b/phabfive/countdown/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Countdown module for phabfive."""
+
+from phabfive.countdown.core import Countdown
+
+__all__ = ["Countdown"]

--- a/phabfive/countdown/core.py
+++ b/phabfive/countdown/core.py
@@ -1,0 +1,367 @@
+# -*- coding: utf-8 -*-
+"""Core countdown functionality for phabfive."""
+
+import datetime
+import re
+import time
+
+from phabricator import APIError
+
+from phabfive.constants import MONOGRAMS
+from phabfive.core import Phabfive
+from phabfive.exceptions import PhabfiveDataException
+from phabfive.maniphest.utils import parse_time_with_unit
+
+
+class Countdown(Phabfive):
+    def __init__(self):
+        super().__init__()
+
+    def _validate_identifier(self, id_):
+        """Validate countdown identifier format (C123)."""
+        return bool(re.match(f"^{MONOGRAMS['countdown']}$", id_))
+
+    def _convert_ids(self, ids):
+        """Convert countdown monograms to integer IDs."""
+        ids_list_int = []
+
+        for id_ in ids:
+            if not self._validate_identifier(id_):
+                raise PhabfiveDataException(
+                    f"Invalid countdown ID '{id_}'. Expected format: C123"
+                )
+            ids_list_int.append(int(id_[1:]))
+
+        return ids_list_int
+
+    def parse_epoch(self, epoch_value):
+        """Parse epoch value from ISO 8601 or relative time format.
+
+        Supports:
+        - ISO 8601: "2026-06-15T10:00:00", "2026-06-15"
+        - Relative future: "+7d", "+2w", "+1m", "+1y", "+4h"
+        - Unix timestamp: "1718438400"
+
+        Returns:
+            Unix timestamp (int)
+        """
+        if epoch_value is None:
+            return None
+
+        epoch_str = str(epoch_value).strip()
+
+        # Handle relative time (+ prefix indicates future)
+        if epoch_str.startswith("+"):
+            relative_part = epoch_str[1:]  # Remove + prefix
+            days = parse_time_with_unit(relative_part)
+            # Convert days to seconds and add to current time
+            seconds = int(days * 24 * 3600)
+            return int(time.time()) + seconds
+
+        # Handle Unix timestamp
+        if epoch_str.isdigit():
+            return int(epoch_str)
+
+        # Handle ISO 8601 format
+        formats = [
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%dT%H:%M",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%d %H:%M",
+            "%Y-%m-%d",
+        ]
+
+        for fmt in formats:
+            try:
+                dt = datetime.datetime.strptime(epoch_str, fmt)
+                return int(dt.timestamp())
+            except ValueError:
+                continue
+
+        raise PhabfiveDataException(
+            f"Invalid epoch format: '{epoch_value}'. "
+            "Expected ISO 8601 (2026-06-15T10:00:00), "
+            "relative time (+7d, +2w, +1m), or Unix timestamp"
+        )
+
+    def get_countdowns(self, query_key=None, attachments=None, constraints=None):
+        """Retrieve countdown objects from Phabricator.
+
+        Args:
+            query_key: Query key (defaults to "all")
+            attachments: Optional attachments
+            constraints: Search constraints
+
+        Returns:
+            List of countdown data dicts
+        """
+        query_key = query_key or "all"
+        attachments = attachments or {}
+        constraints = constraints or {}
+
+        response = self.phab.countdown.search(
+            queryKey=query_key,
+            attachments=attachments,
+            constraints=constraints,
+        )
+
+        return response.get("data", [])
+
+    def countdown_show(self, countdown_ids):
+        """Get detailed countdown information for display.
+
+        Args:
+            countdown_ids: List of countdown IDs (integers, without C prefix)
+
+        Returns:
+            dict with 'countdowns' key containing list of countdown data
+            formatted like maniphest (with nested Countdown: section)
+        """
+        countdowns = self.get_countdowns(
+            constraints={"ids": countdown_ids},
+        )
+
+        if not countdowns:
+            raise PhabfiveDataException("No countdowns found")
+
+        result = []
+        for countdown in countdowns:
+            monogram = f"C{countdown['id']}"
+            url = self.get_countdown_url(countdown["id"])
+
+            fields = countdown.get("fields", {})
+            epoch_ts = fields.get("epoch")
+
+            # Build nested Countdown section (like maniphest Task section)
+            # Display label is "Name" to match Phorge web UI (even though API field is "title")
+            countdown_fields = {
+                "Name": fields.get("title", ""),
+                "Epoch": self._format_epoch(epoch_ts),
+                "Remaining": self._format_remaining(epoch_ts),
+                "Status": fields.get("status", "active"),
+            }
+
+            # Add description if available (API returns {"raw": "...", "rendered": "..."})
+            description_raw = fields.get("description", {}).get("raw", "")
+            if description_raw:
+                countdown_fields["Description"] = description_raw
+
+            countdown_data = {
+                "_url": url,
+                "_link": self.format_link(url, monogram),
+                "_epoch_unix": epoch_ts,
+                "Countdown": countdown_fields,
+            }
+
+            # Resolve author name from PHID and add to Countdown section
+            author_phid = fields.get("authorPHID")
+            if author_phid:
+                countdown_data["_author"] = self._resolve_phid_to_name(author_phid)
+
+            result.append(countdown_data)
+
+        return {"countdowns": result}
+
+    def _format_epoch(self, epoch_ts):
+        """Format epoch timestamp to ISO 8601 string."""
+        if epoch_ts:
+            dt = datetime.datetime.fromtimestamp(epoch_ts)
+            return dt.strftime("%Y-%m-%dT%H:%M:%S")
+        return None
+
+    def _format_remaining(self, epoch_ts):
+        """Format remaining time until epoch in human-readable form."""
+        if not epoch_ts:
+            return None
+
+        now = int(time.time())
+        diff = epoch_ts - now
+
+        if diff <= 0:
+            return "Completed"
+
+        # Calculate units
+        days = diff // (24 * 3600)
+        hours = (diff % (24 * 3600)) // 3600
+        minutes = (diff % 3600) // 60
+
+        if days > 0:
+            return f"{days}d {hours}h remaining"
+        elif hours > 0:
+            return f"{hours}h {minutes}m remaining"
+        else:
+            return f"{minutes}m remaining"
+
+    def _resolve_phid_to_name(self, phid):
+        """Resolve a PHID to a human-readable name."""
+        try:
+            response = self.phab.phid.query(phids=[phid])
+            if response and phid in response:
+                return response[phid].get("name", phid)
+        except Exception:
+            pass
+        return phid
+
+    def create_countdown(
+        self,
+        title,
+        epoch,
+        description=None,
+        tags=None,
+        subscribers=None,
+    ):
+        """Create a new countdown.
+
+        Args:
+            title: Countdown title
+            epoch: Target date/time (ISO 8601, relative, or Unix timestamp)
+            description: Optional description
+            tags: List of project tags
+            subscribers: List of subscriber usernames
+
+        Returns:
+            dict with countdown object info
+        """
+        tags = tags if tags else []
+        subscribers = subscribers if subscribers else []
+
+        # Parse epoch to Unix timestamp
+        epoch_ts = self.parse_epoch(epoch)
+
+        transactions = [
+            {"type": "name", "value": title},
+            {"type": "epoch", "value": epoch_ts},
+        ]
+
+        if description:
+            transactions.append({"type": "description", "value": description})
+        if tags:
+            transactions.append({"type": "projects.add", "value": tags})
+        if subscribers:
+            transactions.append({"type": "subscribers.add", "value": subscribers})
+
+        try:
+            result = self.phab.countdown.edit(transactions=transactions)
+        except APIError as e:
+            raise PhabfiveDataException(str(e).replace("ERR-CONDUIT-CORE: ", ""))
+
+        return result["object"]
+
+    def edit_countdown(
+        self,
+        countdown_id,
+        title=None,
+        epoch=None,
+        description=None,
+        tags=None,
+        subscribers=None,
+        dry_run=False,
+    ):
+        """Edit an existing countdown.
+
+        Args:
+            countdown_id: Countdown ID (integer, without C prefix)
+            title: New title (None to keep current)
+            epoch: New epoch (None to keep current)
+            description: New description (None to keep current)
+            tags: List of project tags to add
+            subscribers: List of subscriber usernames to add
+            dry_run: If True, return changes without applying
+
+        Returns:
+            dict with changes made or to be made
+        """
+        transactions = []
+        changes = []
+
+        if title is not None:
+            transactions.append({"type": "name", "value": title})
+            changes.append({"field": "Name", "new": title})
+
+        if epoch is not None:
+            epoch_ts = self.parse_epoch(epoch)
+            transactions.append({"type": "epoch", "value": epoch_ts})
+            changes.append({"field": "Epoch", "new": self._format_epoch(epoch_ts)})
+
+        if description is not None:
+            transactions.append({"type": "description", "value": description})
+            changes.append({"field": "Description", "new": "(updated)"})
+
+        if tags:
+            transactions.append({"type": "projects.add", "value": tags})
+            changes.append({"field": "Tags", "new": f"Added: {', '.join(tags)}"})
+
+        if subscribers:
+            transactions.append({"type": "subscribers.add", "value": subscribers})
+            changes.append(
+                {"field": "Subscribers", "new": f"Added: {', '.join(subscribers)}"}
+            )
+
+        if not transactions:
+            return {
+                "countdown_id": countdown_id,
+                "changes": [],
+                "message": "No changes specified",
+            }
+
+        if dry_run:
+            return {"countdown_id": countdown_id, "changes": changes, "dry_run": True}
+
+        try:
+            self.phab.countdown.edit(
+                objectIdentifier=f"C{countdown_id}",
+                transactions=transactions,
+            )
+        except APIError as e:
+            raise PhabfiveDataException(str(e).replace("ERR-CONDUIT-CORE: ", ""))
+
+        return {"countdown_id": countdown_id, "changes": changes}
+
+    def add_countdown_comment(self, countdown_id, comment_text):
+        """Add a comment to a countdown.
+
+        Args:
+            countdown_id: Countdown ID (integer, without C prefix)
+            comment_text: The comment text to add
+
+        Returns:
+            dict with 'success' and 'countdown_id' keys
+        """
+        try:
+            self.phab.countdown.edit(
+                objectIdentifier=f"C{countdown_id}",
+                transactions=[{"type": "comment", "value": comment_text}],
+            )
+        except APIError as e:
+            raise PhabfiveDataException(str(e).replace("ERR-CONDUIT-CORE: ", ""))
+
+        return {"success": True, "countdown_id": countdown_id}
+
+    def get_countdown_url(self, countdown_id):
+        """Get the URL for a countdown."""
+        return f"{self.url}/C{countdown_id}"
+
+    def get_countdown_data(self, countdown_id):
+        """Get full countdown data for editing.
+
+        Args:
+            countdown_id: Countdown ID (integer, without C prefix)
+
+        Returns:
+            dict with countdown data
+        """
+        countdowns = self.get_countdowns(constraints={"ids": [countdown_id]})
+
+        if not countdowns:
+            raise PhabfiveDataException(f"Countdown C{countdown_id} not found")
+
+        countdown = countdowns[0]
+        fields = countdown.get("fields", {})
+
+        return {
+            "id": countdown["id"],
+            "phid": countdown["phid"],
+            "title": fields.get("title", ""),
+            "epoch": fields.get("epoch"),
+            "description": fields.get("description", {}).get("raw", ""),
+        }


### PR DESCRIPTION
## Summary

Add new countdown module for interacting with Phorge/Phabricator countdowns (C123 monograms).

### Features
- **show**: Display countdown details with remaining time
- **search**: Search by text query or author
- **create**: Create countdowns with ISO 8601 or relative epoch (+7d, +2w)
- **edit**: Modify title, epoch, description, tags, subscribers
- **comment**: Add comments with CLI, stdin, or $EDITOR

### Monogram shortcuts
- `phabfive C1` → `countdown show C1`
- `phabfive C1 "text"` → `countdown comment C1 "text"`

### Output formats
Supports rich (default), yaml, json, and tree output formats.

## Known Issue

Creating or editing countdown epoch via Conduit API currently fails due to an upstream bug in Phorge:
- https://we.phorge.it/T16641

The code is written correctly and will work once the upstream bug is fixed. All other operations (show, search, edit name/description/tags/subscribers, comment) work correctly.

## Test plan

```bash
# Show countdown
phabfive countdown show C1
phabfive --format=yaml C1

# Search
phabfive countdown search "launch"
phabfive countdown search --author=@me

# Edit (name, description, tags work; epoch blocked by upstream bug)
phabfive countdown edit C1 "New Title"
phabfive countdown edit C1 --description="Updated"

# Comment
phabfive countdown comment C1 "Looking forward to this!"
phabfive C1 "Quick comment"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)