### PR TITLE
fix: Match projects case-insensitively in YAML task create

### DIFF
--- a/phabfive/maniphest/core.py
+++ b/phabfive/maniphest/core.py
@@ -34,6 +34,7 @@ from phabfive.maniphest.filters import (
 )
 from phabfive.maniphest.formatters import build_task_boards, build_task_display_data
 from phabfive.maniphest.resolvers import (
+    fetch_project_lookup_maps,
     parse_plus_separated,
     resolve_project_phids,
     resolve_project_phids_for_create,
@@ -1292,12 +1293,11 @@ class Maniphest(Phabfive):
 
         log.debug(username_to_id_mapping)
 
-        # Fetch all projects in phabricator, used to map ticket -> projects later
-        projects_query = self.phab.project.search(constraints={"name": ""})
-        project_name_to_id_map = {
-            project["fields"]["name"]: project["phid"]
-            for project in projects_query["data"]
-        }
+        # Fetch all projects in phabricator, used to map ticket -> projects later.
+        # The map keys lowercased primary names AND slugs/hashtags so that
+        # project references in YAML match case-insensitively,
+        # mirroring resolve_project_phids_for_create() used by the --tag path.
+        project_name_to_id_map, _ = fetch_project_lookup_maps(self.phab)
 
         log.debug(project_name_to_id_map)
 
@@ -1339,7 +1339,7 @@ class Maniphest(Phabfive):
             project_phids = []
 
             for project_name in output.get("projects", []):
-                project_phid = project_name_to_id_map.get(project_name, None)
+                project_phid = project_name_to_id_map.get(project_name.lower(), None)
 
                 if not project_phid:
                     raise PhabfiveRemoteException(

--- a/phabfive/maniphest/resolvers.py
+++ b/phabfive/maniphest/resolvers.py
@@ -335,6 +335,68 @@ def resolve_user_phids(phab, usernames):
         raise PhabfiveRemoteException(f"Failed to resolve users: {e}")
 
 
+def fetch_project_lookup_maps(phab):
+    """
+    Fetch all projects and build case-insensitive lookup maps.
+
+    Uses project.query (paginated) because, unlike project.search, it returns
+    each project's slugs/hashtags inline. Both the primary name and every slug
+    are keyed lowercased so project references match case-insensitively.
+
+    Parameters
+    ----------
+    phab : Phabricator
+        Phabricator API client
+
+    Returns
+    -------
+    tuple(dict, dict)
+        (name_to_phid, name_to_slug) where keys are lowercased primary names
+        and slugs. name_to_slug maps each key to the project's primary URL slug.
+    """
+    try:
+        page_size = 100
+        offset = 0
+        projects_data = {}
+
+        while True:
+            projects_result = phab.project.query(limit=page_size, offset=offset)
+            page_data = projects_result.get("data", {})
+
+            if not page_data:
+                break
+
+            projects_data.update(page_data)
+
+            if len(page_data) < page_size:
+                break
+
+            offset += page_size
+
+    except Exception as e:
+        raise PhabfiveRemoteException(f"Failed to fetch projects: {e}")
+
+    name_to_phid = {}
+    name_to_slug = {}
+    for phid, project_data in projects_data.items():
+        primary_name = project_data["name"]
+        slugs = project_data.get("slugs", [])
+        # Use first slug for URL, or lowercase name if no slugs
+        primary_slug = slugs[0] if slugs else primary_name.lower().replace(" ", "-")
+
+        # Map by primary name (case-insensitive)
+        name_to_phid[primary_name.lower()] = phid
+        name_to_slug[primary_name.lower()] = primary_slug
+
+        # Also map by each slug
+        for slug in slugs:
+            if slug:
+                name_to_phid[slug.lower()] = phid
+                name_to_slug[slug.lower()] = primary_slug
+
+    return name_to_phid, name_to_slug
+
+
 def resolve_project_phids_for_create(phab, project_names):
     """
     Resolve project names to PHIDs and slugs for task creation.
@@ -362,48 +424,7 @@ def resolve_project_phids_for_create(phab, project_names):
     if not project_names:
         return {"phids": [], "slugs": []}
 
-    # Fetch all projects to get both PHIDs and slugs
-    # project.query supports pagination via limit/offset parameters
-    try:
-        page_size = 100
-        offset = 0
-        projects_data = {}
-
-        while True:
-            projects_result = phab.project.query(limit=page_size, offset=offset)
-            page_data = projects_result.get("data", {})
-
-            if not page_data:
-                break
-
-            projects_data.update(page_data)
-
-            if len(page_data) < page_size:
-                break
-
-            offset += page_size
-
-    except Exception as e:
-        raise PhabfiveRemoteException(f"Failed to fetch projects: {e}")
-
-    # Build lookup maps
-    name_to_phid = {}
-    name_to_slug = {}
-    for phid, project_data in projects_data.items():
-        primary_name = project_data["name"]
-        slugs = project_data.get("slugs", [])
-        # Use first slug for URL, or lowercase name if no slugs
-        primary_slug = slugs[0] if slugs else primary_name.lower().replace(" ", "-")
-
-        # Map by primary name (case-insensitive)
-        name_to_phid[primary_name.lower()] = phid
-        name_to_slug[primary_name.lower()] = primary_slug
-
-        # Also map by each slug
-        for slug in slugs:
-            if slug:
-                name_to_phid[slug.lower()] = phid
-                name_to_slug[slug.lower()] = primary_slug
+    name_to_phid, name_to_slug = fetch_project_lookup_maps(phab)
 
     phids = []
     slugs = []

--- a/tests/test_maniphest.py
+++ b/tests/test_maniphest.py
@@ -458,6 +458,49 @@ class TestBuildTaskBoards:
         assert result == {}
 
 
+class TestFetchProjectLookupMaps:
+    """Tests for the case-insensitive project lookup used by task creation."""
+
+    def _mock_phab(self):
+        phab = MagicMock()
+        # project.query returns a dict keyed by PHID, with slugs inline
+        phab.project.query.return_value = {
+            "data": {
+                "PHID-PROJ-dev": {
+                    "name": "Developer-Experience",
+                    "slugs": ["developer-experience", "devx"],
+                },
+                "PHID-PROJ-qa": {"name": "QA", "slugs": ["qa"]},
+            }
+        }
+        return phab
+
+    def test_lowercases_primary_name_and_slugs(self):
+        from phabfive.maniphest.resolvers import fetch_project_lookup_maps
+
+        name_to_phid, name_to_slug = fetch_project_lookup_maps(self._mock_phab())
+
+        # Primary name is matchable case-insensitively
+        assert name_to_phid["developer-experience"] == "PHID-PROJ-dev"
+        # Every slug/hashtag is matchable too
+        assert name_to_phid["devx"] == "PHID-PROJ-dev"
+        assert name_to_phid["qa"] == "PHID-PROJ-qa"
+        # Slug map points at the primary URL slug
+        assert name_to_slug["developer-experience"] == "developer-experience"
+        assert name_to_slug["devx"] == "developer-experience"
+
+    def test_yaml_create_resolves_mixed_case_project(self):
+        """The YAML create path must resolve 'developer-experience' to a PHID
+        even though the project's primary name is 'Developer-Experience'."""
+        from phabfive.maniphest.resolvers import fetch_project_lookup_maps
+
+        name_to_phid, _ = fetch_project_lookup_maps(self._mock_phab())
+
+        # Mirror the lookup performed in create_tasks_from_yaml
+        for reference in ("developer-experience", "DEVELOPER-EXPERIENCE", "DevX"):
+            assert name_to_phid.get(reference.lower()) == "PHID-PROJ-dev"
+
+
 class TestParseSingleCondition:
     def test_parse_backward(self):
         result = _parse_single_condition("backward")


### PR DESCRIPTION
## Summary

Fixes #74. The YAML template create path (`maniphest create --with`) built its own project lookup map keyed on the **exact, case-sensitive** primary name and ignored slugs/hashtags. So a YAML referencing `developer-experience` never matched the project `Developer-Experience` and crashed with `Project '...' is not found`.

The `--tag` create path already resolved projects case-insensitively (by name or hashtag), so this was also a UX-consistency gap between two code paths.

## Changes

- Extract the `--tag` resolver's pagination logic into a shared `fetch_project_lookup_maps()` helper in `resolvers.py`. It uses `project.query` (which returns slugs inline — `project.search` does not expose a slugs attachment) and keys both primary names and every slug **lowercased**.
- The YAML create path now uses this helper and looks up `project_name.lower()`.
- Both create paths now resolve projects identically: by name **or** hashtag, regardless of case.

## Testing

- Added `TestFetchProjectLookupMaps` regression tests.
- Full suite: 386 passed; `ruff check`/`format` clean.
- Verified end-to-end against a local Phorge instance: real (non-dry) create from a YAML referencing the project as both `developer-experience` (lowercase slug) and `DEVELOPER-EXPERIENCE` (uppercase) created tasks with the correct project PHID attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)